### PR TITLE
Fix poolId not a string

### DIFF
--- a/src/routes/quote.js
+++ b/src/routes/quote.js
@@ -53,7 +53,7 @@ router.get(
         poolAllocationRequests: quote.poolAllocationRequests,
       },
       capacities: quote.capacities.map(({ poolId, capacity }) => ({
-        poolId,
+        poolId: poolId.toString(),
         capacity: capacity.map(({ assetId, amount }) => ({ assetId, amount: amount.toString() })),
       })),
     };


### PR DESCRIPTION
Context:

Some of the poolIds are being returned as BigNumber

Solution:

Before sending the response call `toString()` on poolId