### PR TITLE
Feature: Adding usedCapacity to capacity response

### DIFF
--- a/src/lib/capacityEngine.js
+++ b/src/lib/capacityEngine.js
@@ -35,12 +35,10 @@ function capacityEngine(store, productIds, time) {
 
         // traverse all tranches and sum up available capacity on a per-tranche basis
         const available = trancheCapacities
+          // allocations may surpass total capacity in some scenarios
+          .map((capacity, index) => bnMax(capacity.sub(allocations[index]), Zero))
           .slice(firstUsableTrancheIndex) // skip unusable
-          .reduce((total, capacity, index) => {
-            // allocations may surpass total capacity in some scenarios
-            const free = bnMax(capacity.sub(allocations[index]), Zero);
-            return total.add(free);
-          }, Zero);
+          .reduce((total, free) => total.add(free), Zero);
 
         return {
           capacityUsedNXM: used.mul(NXM_PER_ALLOCATION_UNIT).add(capacityUsedNXM),

--- a/src/routes/capacity.js
+++ b/src/routes/capacity.js
@@ -7,8 +7,8 @@ const router = express.Router();
 
 const formatCapacityResult = ({ productId, capacity, capacityUsed }) => ({
   productId,
-  capacity: capacity.map(({ assetId, amount }) => ({ assetId, amount: amount.toString() })),
-  capacityUsed: capacityUsed.toString(),
+  availableCapacity: capacity.map(({ assetId, amount }) => ({ assetId, amount: amount.toString() })),
+  allocatedNxm: capacityUsed.toString(),
 });
 
 router.get(

--- a/src/routes/capacity.js
+++ b/src/routes/capacity.js
@@ -5,9 +5,10 @@ const { asyncRoute } = require('../lib/helpers');
 
 const router = express.Router();
 
-const formatCapacityResult = ({ productId, capacity }) => ({
+const formatCapacityResult = ({ productId, capacity, capacityUsed }) => ({
   productId,
   capacity: capacity.map(({ assetId, amount }) => ({ assetId, amount: amount.toString() })),
+  capacityUsed: capacityUsed.toString(),
 });
 
 router.get(
@@ -17,7 +18,6 @@ router.get(
     const now = BigNumber.from(Date.now()).div(1000);
 
     const response = capacityEngine(store, [], now);
-
     res.json(response.map(capacity => formatCapacityResult(capacity)));
   }),
 );

--- a/test/unit/capacityEngine.js
+++ b/test/unit/capacityEngine.js
@@ -20,7 +20,7 @@ describe('Capacity Engine tests', () => {
     response.forEach((product, i) => {
       expect(product.productId).to.be.equal(capacities[i].productId);
       product.capacity.forEach(({ amount }, j) => {
-        expect(amount.toString()).to.be.equal(capacities[i].capacity[j].amount);
+        expect(amount.toString()).to.be.equal(capacities[i].availableCapacity[j].amount);
       });
     });
   });
@@ -34,7 +34,7 @@ describe('Capacity Engine tests', () => {
 
     expect(product.productId).to.be.equal(expectedCapacities.productId);
     product.capacity.forEach(({ amount }, i) => {
-      expect(amount.toString()).not.to.be.equal(expectedCapacities.capacity[i]);
+      expect(amount.toString()).not.to.be.equal(expectedCapacities.availableCapacity[i]);
     });
   });
 

--- a/test/unit/responses.js
+++ b/test/unit/responses.js
@@ -1,6 +1,7 @@
 const capacities = [
   {
     productId: 0,
+    capacityUsed: '364800000000000000000',
     capacity: [
       {
         assetId: 0,
@@ -18,6 +19,7 @@ const capacities = [
   },
   {
     productId: 1,
+    capacityUsed: '0',
     capacity: [
       {
         assetId: 0,
@@ -35,6 +37,7 @@ const capacities = [
   },
   {
     productId: 2,
+    capacityUsed: '0',
     capacity: [
       {
         assetId: 0,
@@ -66,7 +69,7 @@ const quote = {
   },
   capacities: [
     {
-      poolId: 1,
+      poolId: '1',
       capacity: [
         {
           assetId: '0',

--- a/test/unit/responses.js
+++ b/test/unit/responses.js
@@ -1,8 +1,8 @@
 const capacities = [
   {
     productId: 0,
-    capacityUsed: '364800000000000000000',
-    capacity: [
+    allocatedNxm: '364800000000000000000',
+    availableCapacity: [
       {
         assetId: 0,
         amount: '4761714669056628480',
@@ -19,8 +19,8 @@ const capacities = [
   },
   {
     productId: 1,
-    capacityUsed: '0',
-    capacity: [
+    allocatedNxm: '0',
+    availableCapacity: [
       {
         assetId: 0,
         amount: '2380857334528314240',
@@ -37,8 +37,8 @@ const capacities = [
   },
   {
     productId: 2,
-    capacityUsed: '0',
-    capacity: [
+    allocatedNxm: '0',
+    availableCapacity: [
       {
         assetId: 0,
         amount: '4761714669056628480',


### PR DESCRIPTION
## Context

UI needs used capacities for the products so they can sort it by popularity.
Issue: #31 

## Changes proposed in this pull request 

Added `capacityUsed` calculation to the capacityEngine and added it to response on capacity endpoints

# Test plan
Edited tests to check the capacityUsed prop
