### PR TITLE
fix: Update PRICE_CHANGE_PER_DAY to reflect onchain value

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -17,8 +17,8 @@ module.exports = {
   PRICE_BUMP_RATIO: 20_00, // 20%
 
   // bumped price smoothing
-  // 0.5% per day
-  PRICE_CHANGE_PER_DAY: 50, // 0.5%
+  // 2% per day
+  PRICE_CHANGE_PER_DAY: 200, // 2%
 
   INITIAL_PRICE_DENOMINATOR: 100_00,
   TARGET_PRICE_DENOMINATOR: 100_00,


### PR DESCRIPTION
## Context

The value of the PRICE_CHANGE_PER_DAY param in the Cover.sol contract has been updated from 0.5% to 2% in this proposal: https://app.nexusmutual.io/governance/view?proposalId=213. This hasn't been reflected in the cover router code. This PR fixes this.

There is an argument to be made that these values should be read from the contract instead of being hardcoded.

## Changes proposed in this pull request

Update PRICE_CHANGE_PER_DAY constant from 0.5% to 2%.

## Test plan
Checked the price for Balancer is close to 4% annual, as explained on slack in the bug report.


## Checklist

- [x] Rebased the base branch
- [ ] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [x] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
