### PR TITLE
feat: Add USDC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@ Computes the optimal capacity allocation in order to get the best price on cover
 ## Table of Contents
 
 - [Cover Router](#cover-router)
-    - [Table of Contents](#table-of-contents)
-    - [Setup](#setup)
-    - [Usage](#usage)
-        - [Get Quote](#quote-route)
-        - [Get Capacity](#capacity-route)
+  - [Table of Contents](#table-of-contents)
+  - [Setup](#setup)
+  - [Usage](#usage)
+    - [Quote Route](#quote-route)
+    - [Capacity Route](#capacity-route)
+    - [Capacity Route for a specific product](#capacity-route-for-a-specific-product)
 
 ## Setup
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.0",
       "license": "ISC",
       "dependencies": {
-        "@nexusmutual/deployments": "^2.6.1",
+        "@nexusmutual/deployments": "^2.6.2",
         "convict": "^6.2.4",
         "dotenv": "^16.0.3",
         "ethers": "^5.7.2",
@@ -1480,9 +1480,9 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
     "node_modules/@nexusmutual/deployments": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@nexusmutual/deployments/-/deployments-2.6.1.tgz",
-      "integrity": "sha512-ng7VGnWxb1wwBI8iIlGe2pcoJhhTVhcJ1v3WiCGg3HSKHq34sjpx8Kk+zegVFd1PG5XazhMSG3K8e5lCf43+JA=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@nexusmutual/deployments/-/deployments-2.6.2.tgz",
+      "integrity": "sha512-FQCeO0MYlaz2rQjWrPfRQgeMBwh9B2Zk4F5g4eVMdKeeO59efTC0ONg3QXbql+gYRdXnbxJyFnJMC4nzmL2CsQ=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -7741,9 +7741,9 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
     "@nexusmutual/deployments": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@nexusmutual/deployments/-/deployments-2.6.1.tgz",
-      "integrity": "sha512-ng7VGnWxb1wwBI8iIlGe2pcoJhhTVhcJ1v3WiCGg3HSKHq34sjpx8Kk+zegVFd1PG5XazhMSG3K8e5lCf43+JA=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@nexusmutual/deployments/-/deployments-2.6.2.tgz",
+      "integrity": "sha512-FQCeO0MYlaz2rQjWrPfRQgeMBwh9B2Zk4F5g4eVMdKeeO59efTC0ONg3QXbql+gYRdXnbxJyFnJMC4nzmL2CsQ=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cover-router",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cover-router",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "ISC",
       "dependencies": {
         "@nexusmutual/deployments": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cover-router",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Cover Router",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/NexusMutual/cover-router#readme",
   "dependencies": {
-    "@nexusmutual/deployments": "^2.6.1",
+    "@nexusmutual/deployments": "^2.6.2",
     "convict": "^6.2.4",
     "dotenv": "^16.0.3",
     "ethers": "^5.7.2",

--- a/src/lib/capacityEngine.js
+++ b/src/lib/capacityEngine.js
@@ -102,8 +102,8 @@ function capacityEngine(store, productIds, time, period = 30) {
         ? Zero
         : WeiPerEther.mul(totalPremium).div(capacityAvailableNXM);
 
-      const capacityInAssets = Object.values(assets).map(assetId => ({
-        assetId,
+      const capacityInAssets = Object.keys(assets).map(assetId => ({
+        assetId: Number(assetId),
         amount: capacityAvailableNXM.mul(assetRates[assetId]).div(WeiPerEther),
       }));
 
@@ -136,9 +136,8 @@ function capacityEngine(store, productIds, time, period = 30) {
       }
 
       const { capacityAvailableNXM, capacityUsedNXM, minPrice } = productData;
-
-      const capacityInAssets = Object.values(assets).map(assetId => ({
-        assetId,
+      const capacityInAssets = Object.keys(assets).map(assetId => ({
+        assetId: Number(assetId),
         amount: capacityAvailableNXM.mul(assetRates[assetId]).div(WeiPerEther),
       }));
 

--- a/src/lib/capacityEngine.js
+++ b/src/lib/capacityEngine.js
@@ -104,7 +104,6 @@ function capacityEngine(store, productIds, time, period = 30) {
 
       const capacityInAssets = Object.values(assets).map(assetId => ({
         assetId,
-        // TODO: use asset decimals instead of generic 18 decimals
         amount: capacityAvailableNXM.mul(assetRates[assetId]).div(WeiPerEther),
       }));
 
@@ -140,7 +139,6 @@ function capacityEngine(store, productIds, time, period = 30) {
 
       const capacityInAssets = Object.values(assets).map(assetId => ({
         assetId,
-        // TODO: use asset decimals instead of generic 18 decimals
         amount: capacityAvailableNXM.mul(assetRates[assetId]).div(WeiPerEther),
       }));
 

--- a/src/lib/capacityEngine.js
+++ b/src/lib/capacityEngine.js
@@ -1,6 +1,6 @@
 const { ethers, BigNumber } = require('ethers');
 
-const { selectProductPools, selectProduct } = require('../store/selectors');
+const { selectAssetInfo, selectProduct, selectProductPools } = require('../store/selectors');
 const { NXM_PER_ALLOCATION_UNIT } = require('./constants');
 const { bnMax, bnMin, calculateTrancheId } = require('./helpers');
 const { calculateBasePrice, calculatePremiumPerYear, calculateFixedPricePremiumPerYear } = require('./quoteEngine');
@@ -105,6 +105,7 @@ function capacityEngine(store, productIds, time, period = 30) {
       const capacityInAssets = Object.keys(assets).map(assetId => ({
         assetId: Number(assetId),
         amount: capacityAvailableNXM.mul(assetRates[assetId]).div(WeiPerEther),
+        asset: selectAssetInfo(store, assetId),
       }));
 
       capacities.push({
@@ -139,6 +140,7 @@ function capacityEngine(store, productIds, time, period = 30) {
       const capacityInAssets = Object.keys(assets).map(assetId => ({
         assetId: Number(assetId),
         amount: capacityAvailableNXM.mul(assetRates[assetId]).div(WeiPerEther),
+        asset: selectAssetInfo(store, assetId),
       }));
 
       capacities.push({

--- a/src/lib/capacityEngine.js
+++ b/src/lib/capacityEngine.js
@@ -1,6 +1,6 @@
 const { ethers, BigNumber } = require('ethers');
 
-const { selectAssetInfo, selectProduct, selectProductPools } = require('../store/selectors');
+const { selectAsset, selectProduct, selectProductPools } = require('../store/selectors');
 const { NXM_PER_ALLOCATION_UNIT } = require('./constants');
 const { bnMax, bnMin, calculateTrancheId } = require('./helpers');
 const { calculateBasePrice, calculatePremiumPerYear, calculateFixedPricePremiumPerYear } = require('./quoteEngine');
@@ -105,7 +105,7 @@ function capacityEngine(store, productIds, time, period = 30) {
       const capacityInAssets = Object.keys(assets).map(assetId => ({
         assetId: Number(assetId),
         amount: capacityAvailableNXM.mul(assetRates[assetId]).div(WeiPerEther),
-        asset: selectAssetInfo(store, assetId),
+        asset: selectAsset(store, assetId),
       }));
 
       capacities.push({
@@ -140,7 +140,7 @@ function capacityEngine(store, productIds, time, period = 30) {
       const capacityInAssets = Object.keys(assets).map(assetId => ({
         assetId: Number(assetId),
         amount: capacityAvailableNXM.mul(assetRates[assetId]).div(WeiPerEther),
-        asset: selectAssetInfo(store, assetId),
+        asset: selectAsset(store, assetId),
       }));
 
       capacities.push({

--- a/src/lib/chainApi.js
+++ b/src/lib/chainApi.js
@@ -9,8 +9,10 @@ const createChainApi = async contracts => {
   const stakingProducts = contracts('StakingProducts');
   const stakingViewer = contracts('StakingViewer');
 
+  const NXM_ASSET_ID = '255';
+
   const fetchTokenPriceInAsset = async assetId => {
-    return assetId === 255 ? WeiPerEther : pool.getInternalTokenPriceInAsset(assetId);
+    return assetId === NXM_ASSET_ID ? WeiPerEther : pool.getInternalTokenPriceInAsset(assetId);
   };
 
   const fetchGlobalCapacityRatio = async () => cover.globalCapacityRatio();

--- a/src/lib/quoteEngine.js
+++ b/src/lib/quoteEngine.js
@@ -1,6 +1,6 @@
 const { BigNumber, ethers } = require('ethers');
 const { calculateTrancheId, divCeil } = require('./helpers');
-const { selectAssetRate, selectProductPools, selectProduct } = require('../store/selectors');
+const { selectAssetInfo, selectAssetRate, selectProductPools, selectProduct } = require('../store/selectors');
 
 const { WeiPerEther, Zero, MaxUint256 } = ethers.constants;
 const { formatEther } = ethers.utils;
@@ -272,14 +272,13 @@ const quoteEngine = (store, productId, amount, period, coverAsset) => {
       : calculatePremiumPerYear(amountToAllocate, pool.basePrice, pool.initialCapacityUsed, pool.totalCapacity);
 
     const premiumInNxm = premiumPerYear.mul(period).div(ONE_YEAR);
-
-    // TODO: use asset decimals instead of generic 18 decimals
     const premiumInAsset = premiumInNxm.mul(assetRate).div(WeiPerEther);
 
     const capacityInNxm = pool.totalCapacity.sub(pool.initialCapacityUsed);
     const capacity = Object.entries(assetRates).map(([assetId, rate]) => ({
       assetId,
       amount: capacityInNxm.mul(rate).div(WeiPerEther),
+      asset: selectAssetInfo(store, assetId),
     }));
 
     console.log('Pool:', poolId);

--- a/src/lib/quoteEngine.js
+++ b/src/lib/quoteEngine.js
@@ -213,7 +213,6 @@ const quoteEngine = (store, productId, amount, period, coverAsset) => {
   const firstUsableTrancheId = calculateTrancheId(gracePeriodExpiration);
   const firstUsableTrancheIndex = firstUsableTrancheId - firstActiveTrancheId;
 
-  // TODO: use asset decimals instead of generic 18 decimals
   const coverAmountInNxm = amount.mul(WeiPerEther).div(assetRate);
 
   // rounding up to nearest allocation unit

--- a/src/lib/quoteEngine.js
+++ b/src/lib/quoteEngine.js
@@ -1,6 +1,6 @@
 const { BigNumber, ethers } = require('ethers');
 const { calculateTrancheId, divCeil } = require('./helpers');
-const { selectAssetInfo, selectAssetRate, selectProductPools, selectProduct } = require('../store/selectors');
+const { selectAsset, selectAssetRate, selectProductPools, selectProduct } = require('../store/selectors');
 
 const { WeiPerEther, Zero, MaxUint256 } = ethers.constants;
 const { formatEther } = ethers.utils;
@@ -278,7 +278,7 @@ const quoteEngine = (store, productId, amount, period, coverAsset) => {
     const capacity = Object.entries(assetRates).map(([assetId, rate]) => ({
       assetId,
       amount: capacityInNxm.mul(rate).div(WeiPerEther),
-      asset: selectAssetInfo(store, assetId),
+      asset: selectAsset(store, assetId),
     }));
 
     console.log('Pool:', poolId);

--- a/src/lib/synchronizer.js
+++ b/src/lib/synchronizer.js
@@ -68,7 +68,7 @@ module.exports = async (store, chainApi, eventsApi) => {
 
   const updateAssetRates = async () => {
     const { assets } = store.getState();
-    const assetIds = Object.values(assets);
+    const assetIds = Object.keys(assets);
     for (const assetId of assetIds) {
       const rate = await chainApi.fetchTokenPriceInAsset(assetId);
       store.dispatch({ type: SET_ASSET_RATE, payload: { assetId, rate } });

--- a/src/routes/capacity.js
+++ b/src/routes/capacity.js
@@ -138,7 +138,7 @@ router.get(
  *                       amount:
  *                         type: string
  *                         format: integer
- *                         description: The capacity amount expressed in the smallest unit of the asset
+ *                         description: The capacity amount expressed in the the asset
  *                       asset:
  *                         type: object
  *                         description: An object containing asset info

--- a/src/routes/capacity.js
+++ b/src/routes/capacity.js
@@ -9,7 +9,11 @@ const { formatUnits } = ethers.utils;
 
 const formatCapacityResult = ({ productId, availableCapacity, usedCapacity, minAnnualPrice, maxAnnualPrice }) => ({
   productId,
-  availableCapacity: availableCapacity.map(({ assetId, amount }) => ({ assetId, amount: amount.toString() })),
+  availableCapacity: availableCapacity.map(({ assetId, amount, asset }) => ({
+    assetId,
+    amount: amount.toString(),
+    asset,
+  })),
   allocatedNxm: usedCapacity.toString(),
   minAnnualPrice: formatUnits(minAnnualPrice),
   maxAnnualPrice: formatUnits(maxAnnualPrice),
@@ -48,7 +52,22 @@ const formatCapacityResult = ({ productId, availableCapacity, usedCapacity, minA
  *                         amount:
  *                           type: string
  *                           format: integer
- *                           description: The capacity amount
+ *                           description: The capacity amount expressed in the asset
+ *                         asset:
+ *                           type: object
+ *                           description: An object containing asset info
+ *                           properties:
+ *                             id:
+ *                               type: string
+ *                               format: integer
+ *                               description: The id of the asset
+ *                             symbol:
+ *                               type: string
+ *                               description: The symbol of the asset
+ *                             decimals:
+ *                               type: integer
+ *                               description: The decimals of the asset
+ *                               example: 18
  *                   allocatedNxm:
  *                     type: string
  *                     format: integer
@@ -118,7 +137,23 @@ router.get(
  *                         description: The asset id
  *                       amount:
  *                         type: string
- *                         description: The capacity amount
+ *                         format: integer
+ *                         description: The capacity amount expressed in the smallest unit of the asset
+ *                       asset:
+ *                         type: object
+ *                         description: An object containing asset info
+ *                         properties:
+ *                           id:
+ *                             type: string
+ *                             format: integer
+ *                             description: The id of the asset
+ *                           symbol:
+ *                             type: string
+ *                             description: The symbol of the asset
+ *                           decimals:
+ *                             type: integer
+ *                             description: The decimals of the asset
+ *                             example: 18
  *                 allocatedNxm:
  *                   type: string
  *                   description: The used capacity amount for active covers on the product.

--- a/src/routes/quote.js
+++ b/src/routes/quote.js
@@ -3,6 +3,7 @@ const { BigNumber, ethers } = require('ethers');
 const { quoteEngine } = require('../lib/quoteEngine');
 const { asyncRoute } = require('../lib/helpers');
 const { TARGET_PRICE_DENOMINATOR } = require('../lib/constants');
+const { selectAssetDecimals, selectAssetSymbol } = require('../store/selectors');
 
 const router = express.Router();
 const { Zero } = ethers.constants;
@@ -169,6 +170,10 @@ router.get(
         premiumInNXM: quote.premiumInNXM.toString(),
         premiumInAsset: quote.premiumInAsset.toString(),
         poolAllocationRequests: quote.poolAllocationRequests,
+        asset: {
+          symbol: selectAssetSymbol(store, coverAsset),
+          decimals: selectAssetDecimals(store, coverAsset),
+        },
       },
       capacities: quote.capacities.map(({ poolId, capacity }) => ({
         poolId: poolId.toString(),

--- a/src/routes/quote.js
+++ b/src/routes/quote.js
@@ -3,7 +3,7 @@ const { BigNumber, ethers } = require('ethers');
 const { quoteEngine } = require('../lib/quoteEngine');
 const { asyncRoute } = require('../lib/helpers');
 const { TARGET_PRICE_DENOMINATOR } = require('../lib/constants');
-const { selectAssetDecimals, selectAssetSymbol } = require('../store/selectors');
+const { selectAssetInfo } = require('../store/selectors');
 
 const router = express.Router();
 const { Zero } = ethers.constants;
@@ -90,8 +90,12 @@ const { Zero } = ethers.constants;
  *                             default: false
  *                     asset:
  *                       type: object
- *                       description: An object containing cover asset
+ *                       description: An object containing cover asset info
  *                       properties:
+ *                         id:
+ *                           type: string
+ *                           format: integer
+ *                           description: The id of the cover asset
  *                         symbol:
  *                           type: string
  *                           description: The symbol of the cover asset
@@ -116,11 +120,26 @@ const { Zero } = ethers.constants;
  *                             assetId:
  *                               type: string
  *                               format: integer
- *                               description: The asset id
+ *                               description: The id of the asset
  *                             amount:
  *                               type: string
  *                               format: integer
- *                               description: The total capacity amount of the pool for the asset.
+ *                               description: The total capacity amount of the pool expressed in the asset.
+ *                             asset:
+ *                               type: object
+ *                               description: An object containing asset info
+ *                               properties:
+ *                                 id:
+ *                                   type: string
+ *                                   format: integer
+ *                                   description: The id of the asset
+ *                                 symbol:
+ *                                   type: string
+ *                                   description: The symbol of the asset
+ *                                 decimals:
+ *                                   type: integer
+ *                                   description: The decimals of the asset
+ *                                   example: 18
  */
 router.get(
   '/quote',
@@ -181,14 +200,11 @@ router.get(
         premiumInNXM: quote.premiumInNXM.toString(),
         premiumInAsset: quote.premiumInAsset.toString(),
         poolAllocationRequests: quote.poolAllocationRequests,
-        asset: {
-          symbol: selectAssetSymbol(store, coverAsset),
-          decimals: selectAssetDecimals(store, coverAsset),
-        },
+        asset: selectAssetInfo(store, coverAsset),
       },
       capacities: quote.capacities.map(({ poolId, capacity }) => ({
         poolId: poolId.toString(),
-        capacity: capacity.map(({ assetId, amount }) => ({ assetId, amount: amount.toString() })),
+        capacity: capacity.map(({ assetId, amount, asset }) => ({ assetId, amount: amount.toString(), asset })),
       })),
     };
 

--- a/src/routes/quote.js
+++ b/src/routes/quote.js
@@ -129,7 +129,7 @@ router.get(
       return res.status(400).send({ error: 'Not enough capacity for the cover amount', response: null });
     }
 
-    if (route.error === 'isDeprecated') {
+    if (route.error && route.error.isDeprecated) {
       return res.status(400).send({ error: 'Product is deprecated', response: null });
     }
 

--- a/src/routes/quote.js
+++ b/src/routes/quote.js
@@ -3,7 +3,7 @@ const { BigNumber, ethers } = require('ethers');
 const { quoteEngine } = require('../lib/quoteEngine');
 const { asyncRoute } = require('../lib/helpers');
 const { TARGET_PRICE_DENOMINATOR } = require('../lib/constants');
-const { selectAssetInfo } = require('../store/selectors');
+const { selectAsset } = require('../store/selectors');
 
 const router = express.Router();
 const { Zero } = ethers.constants;
@@ -200,7 +200,7 @@ router.get(
         premiumInNXM: quote.premiumInNXM.toString(),
         premiumInAsset: quote.premiumInAsset.toString(),
         poolAllocationRequests: quote.poolAllocationRequests,
-        asset: selectAssetInfo(store, coverAsset),
+        asset: selectAsset(store, coverAsset),
       },
       capacities: quote.capacities.map(({ poolId, capacity }) => ({
         poolId: poolId.toString(),

--- a/src/routes/quote.js
+++ b/src/routes/quote.js
@@ -88,6 +88,17 @@ const { Zero } = ethers.constants;
  *                             type: boolean
  *                             description: Skip
  *                             default: false
+ *                     asset:
+ *                       type: object
+ *                       description: An object containing cover asset
+ *                       properties:
+ *                         symbol:
+ *                           type: string
+ *                           description: The symbol of the cover asset
+ *                         decimals:
+ *                           type: integer
+ *                           description: The decimals of the cover asset
+ *                           example: 18
  *                 capacities:
  *                   type: array
  *                   description: Show the pools with sufficient (and cheapest) capacity for the requested cover.

--- a/src/store/cache.js
+++ b/src/store/cache.js
@@ -27,7 +27,13 @@ const load = defaultState => {
   }
 
   const contents = fs.readFileSync(stateFile, 'utf8');
-  return parseCache(JSON.parse(contents));
+
+  const parsedData = parseCache(JSON.parse(contents));
+
+  // refresh constants values
+  parsedData.assets = { ...defaultState.assets };
+
+  return parsedData;
 };
 
 const save = state => {

--- a/src/store/reducer.js
+++ b/src/store/reducer.js
@@ -8,7 +8,7 @@ const {
 
 const initialState = {
   assetRates: {}, // assetId -> rate
-  assets: { ETH: 0, DAI: 1, NXM: 255 },
+  assets: { ETH: 0, DAI: 1, USDC: 6, NXM: 255 },
   globalCapacityRatio: 0,
   poolProducts: {}, // {productId}_{poolId} -> { allocations, trancheCapacities }
   productPoolIds: {}, // productId -> [ poolIds ]

--- a/src/store/reducer.js
+++ b/src/store/reducer.js
@@ -9,10 +9,10 @@ const {
 const initialState = {
   assetRates: {}, // assetId -> rate
   assets: {
-    0: { symbol: 'ETH', decimals: 18 },
-    1: { symbol: 'DAI', decimals: 18 },
-    6: { symbol: 'USDC', decimals: 6 },
-    255: { symbol: 'NXM', decimals: 18 },
+    0: { id: '0', symbol: 'ETH', decimals: 18 },
+    1: { id: '1', symbol: 'DAI', decimals: 18 },
+    6: { id: '6', symbol: 'USDC', decimals: 6 },
+    255: { id: '255', symbol: 'NXM', decimals: 18 },
   },
   globalCapacityRatio: 0,
   poolProducts: {}, // {productId}_{poolId} -> { allocations, trancheCapacities }

--- a/src/store/reducer.js
+++ b/src/store/reducer.js
@@ -8,7 +8,12 @@ const {
 
 const initialState = {
   assetRates: {}, // assetId -> rate
-  assets: { ETH: 0, DAI: 1, USDC: 6, NXM: 255 },
+  assets: {
+    0: { symbol: 'ETH', decimals: 18 },
+    1: { symbol: 'DAI', decimals: 18 },
+    6: { symbol: 'USDC', decimals: 6 },
+    255: { symbol: 'NXM', decimals: 18 },
+  },
   globalCapacityRatio: 0,
   poolProducts: {}, // {productId}_{poolId} -> { allocations, trancheCapacities }
   productPoolIds: {}, // productId -> [ poolIds ]

--- a/src/store/selectors.js
+++ b/src/store/selectors.js
@@ -17,20 +17,15 @@ const selectProductPools = (store, productId) => {
   });
 };
 
-const selectAssetSymbol = (store, assetId) => {
+const selectAssetInfo = (store, assetId) => {
   const { assets } = store.getState();
-  return assets[assetId].symbol;
-};
-
-const selectAssetDecimals = (store, assetId) => {
-  const { assets } = store.getState();
-  return assets[assetId].decimals;
+  const { id, symbol, decimals } = assets[assetId];
+  return { id, symbol, decimals };
 };
 
 module.exports = {
   selectAssetRate,
-  selectAssetSymbol,
-  selectAssetDecimals,
+  selectAssetInfo,
   selectProduct,
   selectProductPools,
 };

--- a/src/store/selectors.js
+++ b/src/store/selectors.js
@@ -19,12 +19,18 @@ const selectProductPools = (store, productId) => {
 
 const selectAssetSymbol = (store, assetId) => {
   const { assets } = store.getState();
-  return Object.keys(assets).find(key => assets[key] === assetId);
+  return assets[assetId].symbol;
+};
+
+const selectAssetDecimals = (store, assetId) => {
+  const { assets } = store.getState();
+  return assets[assetId].decimals;
 };
 
 module.exports = {
   selectAssetRate,
   selectAssetSymbol,
+  selectAssetDecimals,
   selectProduct,
   selectProductPools,
 };

--- a/src/store/selectors.js
+++ b/src/store/selectors.js
@@ -17,15 +17,14 @@ const selectProductPools = (store, productId) => {
   });
 };
 
-const selectAssetInfo = (store, assetId) => {
+const selectAsset = (store, assetId) => {
   const { assets } = store.getState();
-  const { id, symbol, decimals } = assets[assetId];
-  return { id, symbol, decimals };
+  return assets[assetId];
 };
 
 module.exports = {
   selectAssetRate,
-  selectAssetInfo,
+  selectAsset,
   selectProduct,
   selectProductPools,
 };

--- a/test/mocks/store.js
+++ b/test/mocks/store.js
@@ -8,10 +8,10 @@ const store = {
     255: BigNumber.from(1000000000000000000n),
   },
   assets: {
-    ETH: 0,
-    DAI: 1,
-    USDC: 6,
-    NXM: 255,
+    0: { symbol: 'ETH', decimals: 18 },
+    1: { symbol: 'DAI', decimals: 18 },
+    6: { symbol: 'USDC', decimals: 6 },
+    255: { symbol: 'NXM', decimals: 18 },
   },
   globalCapacityRatio: BigNumber.from(20000),
   poolProducts: {

--- a/test/mocks/store.js
+++ b/test/mocks/store.js
@@ -8,10 +8,10 @@ const store = {
     255: BigNumber.from(1000000000000000000n),
   },
   assets: {
-    0: { symbol: 'ETH', decimals: 18 },
-    1: { symbol: 'DAI', decimals: 18 },
-    6: { symbol: 'USDC', decimals: 6 },
-    255: { symbol: 'NXM', decimals: 18 },
+    0: { id: '0', symbol: 'ETH', decimals: 18 },
+    1: { id: '1', symbol: 'DAI', decimals: 18 },
+    6: { id: '6', symbol: 'USDC', decimals: 6 },
+    255: { id: '255', symbol: 'NXM', decimals: 18 },
   },
   globalCapacityRatio: BigNumber.from(20000),
   poolProducts: {

--- a/test/mocks/store.js
+++ b/test/mocks/store.js
@@ -4,11 +4,13 @@ const store = {
   assetRates: {
     0: BigNumber.from(10280040304526400n),
     1: BigNumber.from(28724439013819923654n),
+    6: BigNumber.from(28724439n),
     255: BigNumber.from(1000000000000000000n),
   },
   assets: {
     ETH: 0,
     DAI: 1,
+    USDC: 6,
     NXM: 255,
   },
   globalCapacityRatio: BigNumber.from(20000),

--- a/test/unit/cache.js
+++ b/test/unit/cache.js
@@ -25,7 +25,7 @@ describe('cache', function () {
     const state = { test: 'test2' };
     fs.writeFileSync(stateFile, JSON.stringify(state, null, 2));
     const loadedState = load(defaultState);
-    expect(loadedState).to.deep.equal(state);
+    expect(loadedState).to.deep.equal({ ...state, assets: {} });
   });
 
   it('save should write the state to the file', function () {

--- a/test/unit/capacityEngine.js
+++ b/test/unit/capacityEngine.js
@@ -5,7 +5,7 @@ const { BigNumber } = require('ethers');
 const capacityEngine = require('../../src/lib/capacityEngine');
 const mockStore = require('../mocks/store');
 const { capacities } = require('./responses');
-const { selectAssetInfo } = require('../../src/store/selectors');
+const { selectAsset } = require('../../src/store/selectors');
 
 describe('Capacity Engine tests', () => {
   const store = { getState: () => null };
@@ -23,7 +23,7 @@ describe('Capacity Engine tests', () => {
       expect(product.productId).to.be.equal(capacities[i].productId);
       product.availableCapacity.forEach(({ assetId, amount, asset }, j) => {
         expect(amount.toString()).to.be.equal(capacities[i].availableCapacity[j].amount);
-        expect(asset).to.deep.equal(selectAssetInfo(store, assetId));
+        expect(asset).to.deep.equal(selectAsset(store, assetId));
       });
     });
   });
@@ -38,7 +38,7 @@ describe('Capacity Engine tests', () => {
     expect(product.productId).to.be.equal(expectedCapacities.productId);
     product.availableCapacity.forEach(({ assetId, amount, asset }, i) => {
       expect(amount.toString()).not.to.be.equal(expectedCapacities.availableCapacity[i]);
-      expect(asset).to.deep.equal(selectAssetInfo(store, assetId));
+      expect(asset).to.deep.equal(selectAsset(store, assetId));
     });
   });
 

--- a/test/unit/capacityEngine.js
+++ b/test/unit/capacityEngine.js
@@ -5,6 +5,7 @@ const { BigNumber } = require('ethers');
 const capacityEngine = require('../../src/lib/capacityEngine');
 const mockStore = require('../mocks/store');
 const { capacities } = require('./responses');
+const { selectAssetInfo } = require('../../src/store/selectors');
 
 describe('Capacity Engine tests', () => {
   const store = { getState: () => null };
@@ -20,8 +21,9 @@ describe('Capacity Engine tests', () => {
 
     response.forEach((product, i) => {
       expect(product.productId).to.be.equal(capacities[i].productId);
-      product.availableCapacity.forEach(({ amount }, j) => {
+      product.availableCapacity.forEach(({ assetId, amount, asset }, j) => {
         expect(amount.toString()).to.be.equal(capacities[i].availableCapacity[j].amount);
+        expect(asset).to.deep.equal(selectAssetInfo(store, assetId));
       });
     });
   });
@@ -34,8 +36,9 @@ describe('Capacity Engine tests', () => {
     const [expectedCapacities] = capacities;
 
     expect(product.productId).to.be.equal(expectedCapacities.productId);
-    product.availableCapacity.forEach(({ amount }, i) => {
+    product.availableCapacity.forEach(({ assetId, amount, asset }, i) => {
       expect(amount.toString()).not.to.be.equal(expectedCapacities.availableCapacity[i]);
+      expect(asset).to.deep.equal(selectAssetInfo(store, assetId));
     });
   });
 

--- a/test/unit/quoteEngine.js
+++ b/test/unit/quoteEngine.js
@@ -1,6 +1,6 @@
 const sinon = require('sinon');
 const {
-  utils: { parseEther },
+  utils: { parseEther, parseUnits },
 } = require('ethers');
 const { expect } = require('chai');
 const { quoteEngine } = require('../../src/lib/quoteEngine');
@@ -41,6 +41,20 @@ describe('Quote Engine tests', () => {
     expect(quote.premiumInAsset.toString()).to.be.equal('1644139670895139282');
     expect(quote.coverAmountInNxm.toString()).to.be.equal('34820000000000000000');
     expect(quote.coverAmountInAsset.toString()).to.be.equal('1000184966461209741632');
+  });
+
+  it('should return quote in USDC for product 1 for minimal cover period', () => {
+    sinon.stub(store, 'getState').callsFake(() => mockStore);
+    const productId = 1;
+    const amount = parseUnits('1000', 6);
+
+    const [quote] = quoteEngine(store, productId, amount, MIN_COVER_PERIOD, 6);
+
+    expect(quote.poolId).to.be.equal(1);
+    expect(quote.premiumInNxm.toString()).to.be.equal('57238356164383561');
+    expect(quote.premiumInAsset.toString()).to.be.equal('1644139');
+    expect(quote.coverAmountInNxm.toString()).to.be.equal('34820000000000000000');
+    expect(quote.coverAmountInAsset.toString()).to.be.equal('1000184965');
   });
 
   it('should return quote with split across 2 pools', () => {

--- a/test/unit/responses.js
+++ b/test/unit/responses.js
@@ -1,3 +1,11 @@
+// NOTE: this must be updated is reducer.js inititaState.assets is updated
+const assets = {
+  0: { symbol: 'ETH', decimals: 18 },
+  1: { symbol: 'DAI', decimals: 18 },
+  6: { symbol: 'USDC', decimals: 6 },
+  255: { symbol: 'NXM', decimals: 18 },
+};
+
 const capacities = [
   {
     productId: 0,
@@ -97,19 +105,61 @@ const capacities = [
   },
 ];
 
-const quote = {
+const ethQuote = {
+  annualPrice: '279',
+  premiumInNXM: '2718347967479674796',
+  premiumInAsset: '27944726667418476',
+  totalCoverAmountInAsset: '1000042320824328192',
+  poolAllocationRequests: [
+    {
+      poolId: '1',
+      coverAmountInAsset: '1000042320824328192',
+      skip: false,
+    },
+  ],
+};
+
+const daiQuote = {
+  annualPrice: '199',
+  premiumInNXM: '800000000000000',
+  premiumInAsset: '22979551211055938',
+  totalCoverAmountInAsset: '1148977560552796946',
+  poolAllocationRequests: [
+    {
+      poolId: '1',
+      coverAmountInAsset: '1148977560552796946',
+      skip: false,
+    },
+  ],
+};
+
+const usdcQuote = {
+  annualPrice: '199',
+  premiumInNXM: '7000000000000000',
+  premiumInAsset: '201071',
+  totalCoverAmountInAsset: '10053553',
+  poolAllocationRequests: [
+    {
+      poolId: '1',
+      coverAmountInAsset: '10053553',
+      skip: false,
+    },
+  ],
+};
+
+const quoteMapping = {
+  0: ethQuote,
+  1: daiQuote,
+  6: usdcQuote,
+};
+
+const getQuote = assetId => ({
   quote: {
-    annualPrice: '279',
-    premiumInNXM: '2718347967479674796',
-    premiumInAsset: '27944726667418476',
-    totalCoverAmountInAsset: '1000042320824328192',
-    poolAllocationRequests: [
-      {
-        poolId: '1',
-        coverAmountInAsset: '1000042320824328192',
-        skip: false,
-      },
-    ],
+    ...quoteMapping[assetId],
+    asset: {
+      symbol: assets[assetId].symbol,
+      decimals: assets[assetId].decimals,
+    },
   },
   capacities: [
     {
@@ -134,9 +184,9 @@ const quote = {
       ],
     },
   ],
-};
+});
 
 module.exports = {
   capacities,
-  quote,
+  getQuote,
 };

--- a/test/unit/responses.js
+++ b/test/unit/responses.js
@@ -14,6 +14,10 @@ const capacities = [
         amount: '13305160151201388636532',
       },
       {
+        assetId: 6,
+        amount: '13305160144',
+      },
+      {
         assetId: 255,
         amount: '463200000000000000000',
       },
@@ -32,6 +36,10 @@ const capacities = [
       {
         assetId: 1,
         amount: '14718402550681328880309',
+      },
+      {
+        assetId: 6,
+        amount: '14718402543',
       },
       {
         assetId: 255,
@@ -54,6 +62,10 @@ const capacities = [
         amount: '13305160151201388636532',
       },
       {
+        assetId: 6,
+        amount: '13305160144',
+      },
+      {
         assetId: 255,
         amount: '463200000000000000000',
       },
@@ -71,13 +83,17 @@ const capacities = [
         amount: '1752525132313136206805332',
       },
       {
+        assetId: 6,
+        amount: '1752525131469',
+      },
+      {
         assetId: 255,
         amount: '61011640000000000000000',
       },
     ],
     allocatedNxm: '32725200000000000000000',
-    minAnnualPrice: '0.09',
-    maxAnnualPrice: '0.112156212788396874',
+    minAnnualPrice: '0.0775',
+    maxAnnualPrice: '0.104190714614767679',
   },
 ];
 
@@ -106,6 +122,10 @@ const quote = {
         {
           assetId: '1',
           amount: '2826484798959880487553',
+        },
+        {
+          assetId: '6',
+          amount: '2826484797',
         },
         {
           assetId: '255',

--- a/test/unit/responses.js
+++ b/test/unit/responses.js
@@ -1,9 +1,9 @@
-// NOTE: this must be updated is reducer.js inititaState.assets is updated
+// NOTE: this must be updated if reducer.js initialState.assets is updated
 const assets = {
-  0: { symbol: 'ETH', decimals: 18 },
-  1: { symbol: 'DAI', decimals: 18 },
-  6: { symbol: 'USDC', decimals: 6 },
-  255: { symbol: 'NXM', decimals: 18 },
+  0: { id: '0', symbol: 'ETH', decimals: 18 },
+  1: { id: '1', symbol: 'DAI', decimals: 18 },
+  6: { id: '6', symbol: 'USDC', decimals: 6 },
+  255: { id: '255', symbol: 'NXM', decimals: 18 },
 };
 
 const capacities = [
@@ -16,18 +16,22 @@ const capacities = [
       {
         assetId: 0,
         amount: '4761714669056628480',
+        asset: assets[0],
       },
       {
         assetId: 1,
         amount: '13305160151201388636532',
+        asset: assets[1],
       },
       {
         assetId: 6,
         amount: '13305160144',
+        asset: assets[6],
       },
       {
         assetId: 255,
         amount: '463200000000000000000',
+        asset: assets[255],
       },
     ],
   },
@@ -40,18 +44,22 @@ const capacities = [
       {
         assetId: 0,
         amount: '5267492652039327360',
+        asset: assets[0],
       },
       {
         assetId: 1,
         amount: '14718402550681328880309',
+        asset: assets[1],
       },
       {
         assetId: 6,
         amount: '14718402543',
+        asset: assets[6],
       },
       {
         assetId: 255,
         amount: '512400000000000000000',
+        asset: assets[255],
       },
     ],
   },
@@ -64,18 +72,22 @@ const capacities = [
       {
         assetId: 0,
         amount: '4761714669056628480',
+        asset: assets[0],
       },
       {
         assetId: 1,
         amount: '13305160151201388636532',
+        asset: assets[1],
       },
       {
         assetId: 6,
         amount: '13305160144',
+        asset: assets[6],
       },
       {
         assetId: 255,
         amount: '463200000000000000000',
+        asset: assets[255],
       },
     ],
   },
@@ -85,18 +97,22 @@ const capacities = [
       {
         assetId: 0,
         amount: '627202118245255087296',
+        asset: assets[0],
       },
       {
         assetId: 1,
         amount: '1752525132313136206805332',
+        asset: assets[1],
       },
       {
         assetId: 6,
         amount: '1752525131469',
+        asset: assets[6],
       },
       {
         assetId: 255,
         amount: '61011640000000000000000',
+        asset: assets[255],
       },
     ],
     allocatedNxm: '32725200000000000000000',
@@ -156,10 +172,7 @@ const quoteMapping = {
 const getQuote = assetId => ({
   quote: {
     ...quoteMapping[assetId],
-    asset: {
-      symbol: assets[assetId].symbol,
-      decimals: assets[assetId].decimals,
-    },
+    asset: assets[assetId],
   },
   capacities: [
     {
@@ -168,18 +181,22 @@ const getQuote = assetId => ({
         {
           assetId: '0',
           amount: '1011555965965397760',
+          asset: assets[0],
         },
         {
           assetId: '1',
           amount: '2826484798959880487553',
+          asset: assets[1],
         },
         {
           assetId: '6',
           amount: '2826484797',
+          asset: assets[6],
         },
         {
           assetId: '255',
           amount: '98400000000000000000',
+          asset: assets[255],
         },
       ],
     },


### PR DESCRIPTION
## Context

Issue: #83 


## Changes proposed in this pull request

- Add USDC as a asset to the store
- Add caching overwrite for constants
- remove comments regarding support for the decimals, because PriceFeedOracle returns rates in asset units
- add asset object to `/quote`, `/capacity` and `/capacity/{productId}` responses
- update openapi docs

`/quote`
```json
{
  "quote": {
    "totalCoverAmountInAsset": "string",
    "annualPrice": "string",
    "premiumInNXM": "string",
    "premiumInAsset": "string",
    "poolAllocationRequests": [
      {
        "poolId": "string",
        "coverAmountInAsset": "string",
        "skip": false
      }
    ],
    "asset": { // <--- new asset field
      "id": "string",
      "symbol": "string",
      "decimals": 18
    }
  },
  "capacities": [
    {
      "poolId": "string",
      "capacity": [
        {
          "assetId": "string",
          "amount": "string",
          "asset": { // <--- new asset field
            "id": "string",
            "symbol": "string",
            "decimals": 18
          }
        }
      ]
    }
  ]
}
```

`/capacity/{productId}`
```json
{
  "productId": 0,
  "availableCapacity": [
    {
      "assetId": 0,
      "amount": "string",
      "asset": { // <--- new asset field
        "id": "string",
        "symbol": "string",
        "decimals": 18
      }
    }
  ],
  "allocatedNxm": "string",
  "minAnnualPrice": "string",
  "maxAnnualPrice": "string"
}
```

`/capacity`
```json
[
  {
    "productId": 0,
    "availableCapacity": [
      {
        "assetId": 0,
        "amount": "string",
        "asset": { // <--- new asset field
          "id": "string",
          "symbol": "string",
          "decimals": 18
        }
      }
    ],
    "allocatedNxm": "string",
    "minAnnualPrice": "string",
    "maxAnnualPrice": "string"
  }
]
```


## Test plan

- Add tests for USDC support
- Add tests for asset object response

## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
