### PR TITLE
fix: Convert assetId to number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cover-router",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cover-router",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Cover Router",
   "main": "src/index.js",
   "engines": {

--- a/src/routes/capacity.js
+++ b/src/routes/capacity.js
@@ -58,8 +58,7 @@ const formatCapacityResult = ({ productId, availableCapacity, usedCapacity, minA
  *                           description: An object containing asset info
  *                           properties:
  *                             id:
- *                               type: string
- *                               format: integer
+ *                               type: integer
  *                               description: The id of the asset
  *                             symbol:
  *                               type: string
@@ -144,8 +143,7 @@ router.get(
  *                         description: An object containing asset info
  *                         properties:
  *                           id:
- *                             type: string
- *                             format: integer
+ *                             type: integer
  *                             description: The id of the asset
  *                           symbol:
  *                             type: string

--- a/src/routes/quote.js
+++ b/src/routes/quote.js
@@ -131,8 +131,7 @@ const { Zero } = ethers.constants;
  *                               description: An object containing asset info
  *                               properties:
  *                                 id:
- *                                   type: string
- *                                   format: integer
+ *                                   type: integer
  *                                   description: The id of the asset
  *                                 symbol:
  *                                   type: string
@@ -205,6 +204,7 @@ router.get(
       },
       capacities: quote.capacities.map(({ poolId, capacity }) => ({
         poolId: poolId.toString(),
+        // NOTE: capacity[n].assetId is currently a string (it should ideally a number - BREAKING CHANGE)
         capacity: capacity.map(({ assetId, amount, asset }) => ({ assetId, amount: amount.toString(), asset })),
       })),
     };

--- a/src/store/reducer.js
+++ b/src/store/reducer.js
@@ -9,10 +9,10 @@ const {
 const initialState = {
   assetRates: {}, // assetId -> rate
   assets: {
-    0: { id: '0', symbol: 'ETH', decimals: 18 },
-    1: { id: '1', symbol: 'DAI', decimals: 18 },
-    6: { id: '6', symbol: 'USDC', decimals: 6 },
-    255: { id: '255', symbol: 'NXM', decimals: 18 },
+    0: { id: 0, symbol: 'ETH', decimals: 18 },
+    1: { id: 1, symbol: 'DAI', decimals: 18 },
+    6: { id: 6, symbol: 'USDC', decimals: 6 },
+    255: { id: 255, symbol: 'NXM', decimals: 18 },
   },
   globalCapacityRatio: 0,
   poolProducts: {}, // {productId}_{poolId} -> { allocations, trancheCapacities }

--- a/test/mocks/store.js
+++ b/test/mocks/store.js
@@ -8,10 +8,10 @@ const store = {
     255: BigNumber.from(1000000000000000000n),
   },
   assets: {
-    0: { id: '0', symbol: 'ETH', decimals: 18 },
-    1: { id: '1', symbol: 'DAI', decimals: 18 },
-    6: { id: '6', symbol: 'USDC', decimals: 6 },
-    255: { id: '255', symbol: 'NXM', decimals: 18 },
+    0: { id: 0, symbol: 'ETH', decimals: 18 },
+    1: { id: 1, symbol: 'DAI', decimals: 18 },
+    6: { id: 6, symbol: 'USDC', decimals: 6 },
+    255: { id: 255, symbol: 'NXM', decimals: 18 },
   },
   globalCapacityRatio: BigNumber.from(20000),
   poolProducts: {

--- a/test/unit/responses.js
+++ b/test/unit/responses.js
@@ -1,9 +1,9 @@
 // NOTE: this must be updated if reducer.js initialState.assets is updated
 const assets = {
-  0: { id: '0', symbol: 'ETH', decimals: 18 },
-  1: { id: '1', symbol: 'DAI', decimals: 18 },
-  6: { id: '6', symbol: 'USDC', decimals: 6 },
-  255: { id: '255', symbol: 'NXM', decimals: 18 },
+  0: { id: 0, symbol: 'ETH', decimals: 18 },
+  1: { id: 1, symbol: 'DAI', decimals: 18 },
+  6: { id: 6, symbol: 'USDC', decimals: 6 },
+  255: { id: 255, symbol: 'NXM', decimals: 18 },
 };
 
 const capacities = [


### PR DESCRIPTION
## Context

open-cover asked why `asset.id` was string and if we would support input of assetId as string.

looking at our smart-contracts it seems we take in assetId as a number `Pool.getAsset(uint assetId)`. So maybe we should enforce that all assetId should be in number format.

Although this is technically a breaking change, since open-cover is the only consumer for now and this was only released earlier today maybe we can fix it otherwise we'll be stuck with this inconsistency.

## Changes proposed in this pull request

* change `asset.id` to number
* update openapi docs

## Test plan

* update test expectations for `asset.id` to be a number

## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [x] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
