### PR TITLE
fix: Fix openapi /quote asset.id docs

### DIFF
--- a/src/routes/quote.js
+++ b/src/routes/quote.js
@@ -94,8 +94,7 @@ const { Zero } = ethers.constants;
  *                       description: An object containing cover asset info
  *                       properties:
  *                         id:
- *                           type: string
- *                           format: integer
+ *                           type: integer
  *                           description: The id of the cover asset
  *                         symbol:
  *                           type: string


### PR DESCRIPTION
## Context

I missed changing one `asset.id` to number in openapi docs 🤦‍♂️

## Changes proposed in this pull request

* change openapi docs /quote `asset.id` to number

## Test plan

* manually ran the openapi docs locally and verified ALL `asset.id` are integers

## Checklist

- [x] Rebased the base branch
- [ ] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [x] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
