### PR TITLE
refactor: Change no capacity return value to empty object

### DIFF
--- a/src/lib/quoteEngine.js
+++ b/src/lib/quoteEngine.js
@@ -123,7 +123,7 @@ const calculatePoolPriceAndCapacity = (totalCapacity, basePrice, usedCapacity, u
  * @param coverAmount
  * @param pools
  * @param useFixedPrice
- * @returns {{lowestCostAllocation: *, lowestCost: *}}
+ * @returns {{lowestCostAllocation: *, lowestCost: *}} - object
  */
 const calculateOptimalPoolAllocation = (coverAmount, pools, useFixedPrice = false) => {
   // Pool Id (number) -> Capacity Amount (BigNumber)
@@ -169,7 +169,7 @@ const calculateOptimalPoolAllocation = (coverAmount, pools, useFixedPrice = fals
 
     if (lowestPricePool.chunk.eq(0)) {
       // not enough total capacity available
-      return [];
+      return {};
     }
 
     const allocationAmount = bnMin(lowestPricePool.chunk, coverAmountLeft);
@@ -216,7 +216,7 @@ const customAllocationPriorityFixedPrice = (amountToAllocate, poolsData, customP
 
   if (coverAmountLeft > 0) {
     // not enough total capacity available
-    return [];
+    return {};
   }
 
   return allocations;

--- a/test/unit/calculateOptimalPoolAllocation.js
+++ b/test/unit/calculateOptimalPoolAllocation.js
@@ -409,7 +409,7 @@ describe('calculateOptimalPoolAllocation', function () {
     expect(optimalAllocations[pool2.poolId].toString()).to.be.equal(parseEther('200').toString());
   });
 
-  it('return empty array when there is on capacity available to allocate', async function () {
+  it('return empty object when there is not enough capacity available to satisfy coverAmount', async function () {
     const pool1 = {
       basePrice: BigNumber.from('200'),
       initialCapacityUsed: parseEther('9500'),
@@ -430,7 +430,7 @@ describe('calculateOptimalPoolAllocation', function () {
 
     const amount = parseEther('1000');
     const allocations = calculateOptimalPoolAllocation(amount, pools);
-    expect(allocations.length).to.be.equal(0);
+    expect(allocations).to.deep.equal({});
   });
 
   it('computes optimal pool allocation across 4 pools', () => {

--- a/test/unit/customAllocationPriorityFixedPrice.js
+++ b/test/unit/customAllocationPriorityFixedPrice.js
@@ -40,7 +40,7 @@ describe('customAllocationPriorityFixedPrice', () => {
     expect(allocations).to.deep.equal(expectedAllocations);
   });
 
-  it('returns empty array when there is no capacity available to allocate', async function () {
+  it('returns empty object when there is not enough capacity available to satisfy coverAmount', async function () {
     const amountToAllocate = BigNumber.from(1000);
     const poolsData = [
       { poolId: 1, totalCapacity: BigNumber.from(500), initialCapacityUsed: BigNumber.from(500) },
@@ -48,6 +48,6 @@ describe('customAllocationPriorityFixedPrice', () => {
       { poolId: 22, totalCapacity: BigNumber.from(500), initialCapacityUsed: BigNumber.from(500) },
     ];
     const allocations = await customAllocationPriorityFixedPrice(amountToAllocate, poolsData, [...poolIdPriority]);
-    expect(allocations).to.deep.equal([]);
+    expect(allocations).to.deep.equal({});
   });
 });


### PR DESCRIPTION
## Context

Currently when there is capacity we return the allocation object, but if there is not enough capacity we return an empty array.

The return value should be consistent, hence changing it to empty object.


## Changes proposed in this pull request

* change return value to empty object on not enough capacity


## Test plan

* fix unit tests

## Checklist

- [x] Rebased the base branch
- [ ] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [x] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
