### PR TITLE
feat: Add custom pool priority for Dialectic Moonphase and Chronograph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cover-router",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cover-router",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "ISC",
       "dependencies": {
         "@nexusmutual/deployments": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cover-router",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Cover Router",
   "main": "src/index.js",
   "engines": {

--- a/src/store/reducer.js
+++ b/src/store/reducer.js
@@ -21,7 +21,7 @@ const initialState = {
   products: {}, // productId -> { product }
   productPriorityPoolsFixedPrice: {
     // NOTE: only fixed price products are currently supported
-    186: [18, 22, 1], //
+    186: [18, 22, 1], // DeltaPrime (UnoRe)
     195: [1, 23, 22, 2, 5], // Dialectic Moonphase
     196: [1, 23, 22, 2, 5], // Dialectic Chronograph
   },

--- a/src/store/reducer.js
+++ b/src/store/reducer.js
@@ -21,7 +21,9 @@ const initialState = {
   products: {}, // productId -> { product }
   productPriorityPoolsFixedPrice: {
     // NOTE: only fixed price products are currently supported
-    186: [18, 22, 1],
+    186: [18, 22, 1], //
+    195: [1, 23, 22, 2, 5], // Dialectic Moonphase
+    196: [1, 23, 22, 2, 5], // Dialectic Chronograph
   },
   trancheId: 0,
 };


### PR DESCRIPTION
## Context

Add Dialectic Moonphase / Chronograph custom priority pools:

* We should configure the cover router to source capacity in the following order of pools: 1, 23, 22, 2, 5

https://nexusmutual.slack.com/archives/C076V9H4ND7/p1719411773569079


## Changes proposed in this pull request

* Add Dialectic Moonphase / Chronograph custom priority pools
  * 1, 23, 22, 2, 5


## Test plan

Please describe the tests cases that you ran to verify your changes. Add further instructions on 
how to run them if needed (i.e. migration / deployment scripts, env vars, etc).


## Checklist

- [ ] Rebased the base branch
- [ ] Attached corresponding Github issue
- [ ] Prefixed the name with the type of change (i.e. feat, chore, test)
- [ ] Performed a self-review of my own code
- [ ] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [ ] Didn't generate new warnings
- [ ] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
