### PR TITLE
fix: Fix custom priority pools order bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cover-router",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cover-router",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "ISC",
       "dependencies": {
         "@nexusmutual/deployments": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cover-router",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Cover Router",
   "main": "src/index.js",
   "engines": {

--- a/src/lib/quoteEngine.js
+++ b/src/lib/quoteEngine.js
@@ -202,9 +202,10 @@ const calculateOptimalPoolAllocation = (coverAmount, pools, useFixedPrice = fals
 const customAllocationPriorityFixedPrice = (amountToAllocate, poolsData, customPoolIdPriority) => {
   const allocations = {};
   let coverAmountLeft = amountToAllocate;
+  const customPoolIdPriorityCopy = customPoolIdPriority.slice(0); // avoid mutation on the customPoolIdPriority array
 
-  while (coverAmountLeft > 0 && customPoolIdPriority.length > 0) {
-    const poolId = customPoolIdPriority.shift();
+  while (coverAmountLeft > 0 && customPoolIdPriorityCopy.length > 0) {
+    const poolId = customPoolIdPriorityCopy.shift();
     const pool = poolsData.find(poolData => poolData.poolId === poolId);
 
     const availableCapacity = pool.totalCapacity.sub(pool.initialCapacityUsed);

--- a/test/unit/customAllocationPriorityFixedPrice.js
+++ b/test/unit/customAllocationPriorityFixedPrice.js
@@ -13,7 +13,7 @@ describe('customAllocationPriorityFixedPrice', () => {
       { poolId: 18, totalCapacity: BigNumber.from(500), initialCapacityUsed: BigNumber.from(100) },
       { poolId: 22, totalCapacity: BigNumber.from(500), initialCapacityUsed: BigNumber.from(200) },
     ];
-    const allocations = await customAllocationPriorityFixedPrice(amountToAllocate, poolsData, [...poolIdPriority]);
+    const allocations = await customAllocationPriorityFixedPrice(amountToAllocate, poolsData, poolIdPriority);
     expect(allocations).to.deep.equal({ 18: BigNumber.from(200) });
   });
 
@@ -24,7 +24,7 @@ describe('customAllocationPriorityFixedPrice', () => {
       { poolId: 18, totalCapacity: BigNumber.from(500), initialCapacityUsed: BigNumber.from(300) },
       { poolId: 22, totalCapacity: BigNumber.from(500), initialCapacityUsed: BigNumber.from(0) },
     ];
-    const allocations = await customAllocationPriorityFixedPrice(amountToAllocate, poolsData, [...poolIdPriority]);
+    const allocations = await customAllocationPriorityFixedPrice(amountToAllocate, poolsData, poolIdPriority);
     expect(allocations).to.deep.equal({ 18: BigNumber.from(200), 22: BigNumber.from(400) });
   });
 
@@ -35,7 +35,7 @@ describe('customAllocationPriorityFixedPrice', () => {
       { poolId: 18, totalCapacity: BigNumber.from(500000), initialCapacityUsed: BigNumber.from(0) },
       { poolId: 22, totalCapacity: BigNumber.from(500000), initialCapacityUsed: BigNumber.from(200000) },
     ];
-    const allocations = await customAllocationPriorityFixedPrice(amountToAllocate, poolsData, [...poolIdPriority]);
+    const allocations = await customAllocationPriorityFixedPrice(amountToAllocate, poolsData, poolIdPriority);
     const expectedAllocations = { 18: BigNumber.from(500000), 22: BigNumber.from(300000), 1: BigNumber.from(200000) };
     expect(allocations).to.deep.equal(expectedAllocations);
   });
@@ -47,7 +47,7 @@ describe('customAllocationPriorityFixedPrice', () => {
       { poolId: 18, totalCapacity: BigNumber.from(500), initialCapacityUsed: BigNumber.from(500) },
       { poolId: 22, totalCapacity: BigNumber.from(500), initialCapacityUsed: BigNumber.from(500) },
     ];
-    const allocations = await customAllocationPriorityFixedPrice(amountToAllocate, poolsData, [...poolIdPriority]);
+    const allocations = await customAllocationPriorityFixedPrice(amountToAllocate, poolsData, poolIdPriority);
     expect(allocations).to.deep.equal({});
   });
 });


### PR DESCRIPTION
## Context

it mutates the reducer state so subsequent calls have empty custom priority pools array which causes it to fail


## Changes proposed in this pull request

* fix bug


## Test plan

* manual test locally


## Checklist

- [x] Rebased the base branch
- [ ] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [ ] Performed a self-review of my own code
- [ ] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [ ] Didn't generate new warnings
- [ ] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
