### PR TITLE
refactor: Throw error if array-int env var value is missing

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -15,7 +15,7 @@ convict.addFormat({
   },
   coerce: function (val) {
     if (!val) {
-      return [];
+      throw new Error('Missing array-int env var');
     }
     const arr = val.replace(/\s+/g, '').split(',');
     return arr.map(numString => parseInt(numString, 10));

--- a/src/lib/quoteEngine.js
+++ b/src/lib/quoteEngine.js
@@ -210,7 +210,7 @@ const customAllocationPriorityFixedPrice = (amountToAllocate, poolsData, customP
     const poolId = customPoolIdPriorityCopy.shift();
     const pool = poolsData.find(poolData => poolData.poolId === poolId);
     if (!pool) {
-      console.warn(`Unable to find pool ${poolId} in poolsData array`, inspect(poolsData, { depth: null }));
+      console.info(`Unable to find pool ${poolId} in poolsData array. Skipping\n`, inspect(poolsData, { depth: null }));
       continue;
     }
 


### PR DESCRIPTION
## Context

(I thought I pushed this change earlier but it seems I pushed AFTER the PR got merged so it was not included)

It's safer to throw if we forget to add the necessary env vars because we're alerted straight away that it's missing.

Returning an empty array obfuscates the missing env var issue and it will fail later with "not enough capacity" and it's not easy to see that the root cause was a missing env var.

## Changes proposed in this pull request

* throw error if array-int env var is missing
* change warn log to info

## Test plan

N/A

## Checklist

- [x] Rebased the base branch
- [ ] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
