### PR TITLE
Fix: use max period tranche id instead of hardcoded number in the loop

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -32,6 +32,7 @@ module.exports = {
   NXM_PER_ALLOCATION_UNIT: WeiPerEther.div(100),
 
   MIN_COVER_PERIOD: 30 * 24 * 3600, // seconds
+  MAX_COVER_PERIOD: 365 * 24 * 3600, // seconds
 
   MIN_UNIT_SIZE_DAI: WeiPerEther.mul(10000), // 10k DAI
 


### PR DESCRIPTION
## Context

When calculating the max price we used hardcoded number of for the loop whitch was 5 as it covers more then a year cover period but if the current branch is at the end and we add grace period to the cover period it also can go to the 6th tranche


## Changes proposed in this pull request

Add calculation for the max period tranche id to be used in the capacity calculation instead of the hardcoded count


## Test plan

Please describe the tests cases that you ran to verify your changes. Add further instructions on 
how to run them if needed (i.e. migration / deployment scripts, env vars, etc).


## Checklist

- [ ] Rebased the base branch
- [ ] Attached corresponding Github issue
- [ ] Prefixed the name with the type of change (i.e. feat, chore, test)
- [ ] Performed a self-review of my own code
- [ ] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [ ] Didn't generate new warnings
- [ ] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
