### PR TITLE
fix: Add margin for available capacity in quote engine

### DIFF
--- a/src/lib/quoteEngine.js
+++ b/src/lib/quoteEngine.js
@@ -214,7 +214,7 @@ const customAllocationPriorityFixedPrice = (amountToAllocate, poolsData, customP
       continue;
     }
 
-    const availableCapacity = pool.totalCapacity.sub(pool.initialCapacityUsed);
+    const availableCapacity = pool.totalCapacity.sub(pool.initialCapacityUsed).mul(99).div(100);
     const poolAllocation = bnMin(availableCapacity, coverAmountLeft);
 
     allocations[poolId] = poolAllocation;

--- a/test/unit/customAllocationPriorityFixedPrice.js
+++ b/test/unit/customAllocationPriorityFixedPrice.js
@@ -25,7 +25,7 @@ describe('customAllocationPriorityFixedPrice', () => {
       { poolId: 22, totalCapacity: BigNumber.from(500), initialCapacityUsed: BigNumber.from(0) },
     ];
     const allocations = await customAllocationPriorityFixedPrice(amountToAllocate, poolsData, poolIdPriority);
-    expect(allocations).to.deep.equal({ 18: BigNumber.from(200), 22: BigNumber.from(400) });
+    expect(allocations).to.deep.equal({ 18: BigNumber.from(198), 22: BigNumber.from(402) });
   });
 
   it('returns pool allocation for 3 with allocation goes to each pool in order of priority', async () => {
@@ -36,7 +36,7 @@ describe('customAllocationPriorityFixedPrice', () => {
       { poolId: 22, totalCapacity: BigNumber.from(500000), initialCapacityUsed: BigNumber.from(200000) },
     ];
     const allocations = await customAllocationPriorityFixedPrice(amountToAllocate, poolsData, poolIdPriority);
-    const expectedAllocations = { 18: BigNumber.from(500000), 22: BigNumber.from(300000), 1: BigNumber.from(200000) };
+    const expectedAllocations = { 18: BigNumber.from(495000), 22: BigNumber.from(297000), 1: BigNumber.from(208000) };
     expect(allocations).to.deep.equal(expectedAllocations);
   });
 

--- a/test/unit/quoteEngine.js
+++ b/test/unit/quoteEngine.js
@@ -99,22 +99,22 @@ describe('Quote Engine tests', () => {
     const [quote1, quote2, quote3] = quoteEngine(store, productId, amount, MIN_COVER_PERIOD, 1);
 
     expect(quote1.poolId).to.be.equal(1); // partially filled
-    expect(quote1.premiumInNxm.toString()).to.be.equal('46158904109589041');
-    expect(quote1.premiumInAsset.toString()).to.be.equal('1325888626040652254');
-    expect(quote1.coverAmountInNxm.toString()).to.be.equal('28080000000000000000');
-    expect(quote1.coverAmountInAsset.toString()).to.be.equal('806582247508063456204');
+    expect(quote1.premiumInNxm.toString()).to.be.equal('104069753424657534');
+    expect(quote1.premiumInAsset.toString()).to.be.equal('2989345285429852478');
+    expect(quote1.coverAmountInNxm.toString()).to.be.equal('63309100000000000000');
+    expect(quote1.coverAmountInAsset.toString()).to.be.equal('1818518381969826928603');
 
     expect(quote2.poolId).to.be.equal(18); // capacity filled
-    expect(quote2.premiumInNxm.toString()).to.be.equal('10973457534246575342');
-    expect(quote2.premiumInAsset.toString()).to.be.equal('315206411713208509713');
-    expect(quote2.coverAmountInNxm.toString()).to.be.equal('1668880000000000000000');
-    expect(quote2.coverAmountInAsset.toString()).to.be.equal('47937641781383794187687');
+    expect(quote2.premiumInNxm.toString()).to.be.equal('10863722958904109589');
+    expect(quote2.premiumInAsset.toString()).to.be.equal('312054347596076424628');
+    expect(quote2.coverAmountInNxm.toString()).to.be.equal('1652191200000000000000');
+    expect(quote2.coverAmountInAsset.toString()).to.be.equal('47458265363569956245810');
 
     expect(quote3.poolId).to.be.equal(22); // capacity filled
-    expect(quote3.premiumInNxm.toString()).to.be.equal('11809917123287671232');
-    expect(quote3.premiumInAsset.toString()).to.be.equal('339233244166144344759');
-    expect(quote3.coverAmountInNxm.toString()).to.be.equal('1854030000000000000000');
-    expect(quote3.coverAmountInAsset.toString()).to.be.equal('53255971664792553052225');
+    expect(quote3.premiumInNxm.toString()).to.be.equal('11691817952054794520');
+    expect(quote3.premiumInAsset.toString()).to.be.equal('335840911724482901321');
+    expect(quote3.coverAmountInNxm.toString()).to.be.equal('1835489700000000000000');
+    expect(quote3.coverAmountInAsset.toString()).to.be.equal('52723411948144627521703');
   });
 
   it('should return empty array for cover over the capacity', () => {


### PR DESCRIPTION
## Context

Max capacity cover buy fails if rates change between getting the quote and the transaction

## Changes proposed in this pull request

Change the maxAvailable capacity when getting a quote


## Test plan

Please describe the tests cases that you ran to verify your changes. Add further instructions on 
how to run them if needed (i.e. migration / deployment scripts, env vars, etc).


## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [ ] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [ ] Didn't generate new warnings
- [ ] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
