### PR TITLE
chore: add new priority pools ordering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cover-router",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cover-router",
-      "version": "2.3.4",
+      "version": "2.3.5",
       "license": "ISC",
       "dependencies": {
         "@nexusmutual/deployments": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cover-router",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "Cover Router",
   "main": "src/index.js",
   "engines": {

--- a/src/config.js
+++ b/src/config.js
@@ -18,13 +18,7 @@ convict.addFormat({
       throw new Error('Missing array-int env var');
     }
     const arr = val.replace(/\s+/g, '').split(',');
-    return arr.map(numString => {
-      const num = parseInt(numString, 10);
-      if (isNaN(num)) {
-        throw new Error(`Invalid integer in array: ${numString}`);
-      }
-      return num;
-    });
+    return arr.map(numString => parseInt(numString, 10));
   },
 });
 

--- a/src/config.js
+++ b/src/config.js
@@ -18,7 +18,13 @@ convict.addFormat({
       throw new Error('Missing array-int env var');
     }
     const arr = val.replace(/\s+/g, '').split(',');
-    return arr.map(numString => parseInt(numString, 10));
+    return arr.map(numString => {
+      const num = parseInt(numString, 10);
+      if (isNaN(num)) {
+        throw new Error(`Invalid integer in array: ${numString}`);
+      }
+      return num;
+    });
   },
 });
 
@@ -62,6 +68,18 @@ const config = convict({
     format: 'array-int',
     env: 'PRIORITY_POOLS_ORDER_196',
     default: [1, 23, 22, 2, 5],
+  },
+  customPoolPriorityOrder227: {
+    doc: 'Custom Pool Priority Order for productId 227 - Base DeFi Pass',
+    format: 'array-int',
+    env: 'PRIORITY_POOLS_ORDER_227',
+    default: [8, 23, 22, 2, 1, 5],
+  },
+  customPoolPriorityOrder233: {
+    doc: 'Custom Pool Priority Order for productId 233 - Relative Finance',
+    format: 'array-int',
+    env: 'PRIORITY_POOLS_ORDER_233',
+    default: [22, 2, 1, 23],
   },
 });
 

--- a/src/store/reducer.js
+++ b/src/store/reducer.js
@@ -25,6 +25,8 @@ const initialState = {
     186: config.get('customPoolPriorityOrder186'), // DeltaPrime (UnoRe)
     195: config.get('customPoolPriorityOrder195'), // Dialectic Moonphase
     196: config.get('customPoolPriorityOrder196'), // Dialectic Chronograph
+    227: config.get('customPoolPriorityOrder227'), // Base DeFi Pass
+    233: config.get('customPoolPriorityOrder233'), // Relative Finance
   },
   trancheId: 0,
 };


### PR DESCRIPTION
## Context

Relates to https://github.com/NexusMutual/sdk/issues/208
Custom Pools Priority Ordering:

The below env vars needs to be added to cover-router env vars
```
PRIORITY_POOLS_ORDER_227=8,23,22,2,1,5
PRIORITY_POOLS_ORDER_233=22,2,1,23
```

## Changes proposed in this pull request

* updated to read the new priority pools ordering env vars


## Test plan

Tested locally on product 227 and logged the state:
```javascript
productPriorityPoolsFixedPrice:  {
  '186': [ 18, 22, 1 ],
  '195': [ 1, 23, 22, 2, 5 ],
  '196': [ 1, 23, 22, 2, 5 ],
  '227': [ 8, 23, 22, 2, 1, 5 ],
  '233': [ 22, 2, 1, 23 ]
}
```

inspected the quote allocations:

```json
    "poolAllocationRequests": [
      {
        "poolId": "2",
        "coverAmountInAsset": "368628193797905307586", (87% of capacity)
        "skip": false
      },
      {
        "poolId": "8",
        "coverAmountInAsset": "363264412514561374629", (99% of capacity)
        "skip": false
      },
      {
        "poolId": "22",
        "coverAmountInAsset": "145659130683951638258", (99% of capacity)
        "skip": false
      },
      {
        "poolId": "23",
        "coverAmountInAsset": "272448479666220822360", (99% of capacity)
        "skip": false
      }
    ],
 ```

## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [ ] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
