### PR TITLE
feat: add custom priority pools env auto read, parse and apply

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cover-router",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cover-router",
-      "version": "2.3.5",
+      "version": "2.3.6",
       "license": "ISC",
       "dependencies": {
         "@nexusmutual/deployments": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cover-router",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "description": "Cover Router",
   "main": "src/index.js",
   "engines": {

--- a/src/config.js
+++ b/src/config.js
@@ -1,27 +1,5 @@
 const convict = require('convict');
 
-// custom array format
-convict.addFormat({
-  name: 'array-int',
-  validate: function (val) {
-    if (!Array.isArray(val)) {
-      throw new Error('must be of type Array');
-    }
-    val.forEach(num => {
-      if (!Number.isInteger(num)) {
-        throw new Error('must contain only integers');
-      }
-    });
-  },
-  coerce: function (val) {
-    if (!val) {
-      throw new Error('Missing array-int env var');
-    }
-    const arr = val.replace(/\s+/g, '').split(',');
-    return arr.map(numString => parseInt(numString, 10));
-  },
-});
-
 const config = convict({
   port: {
     doc: 'The port to bind.',
@@ -45,37 +23,29 @@ const config = convict({
     env: 'POLLING_INTERVAL',
     default: 30_000,
   },
-  customPoolPriorityOrder186: {
-    doc: 'Custom Pool Priority Order for productId 186 - DeltaPrime (UnoRe)',
-    format: 'array-int',
-    env: 'PRIORITY_POOLS_ORDER_186',
-    default: [18, 22, 1],
-  },
-  customPoolPriorityOrder195: {
-    doc: 'Custom Pool Priority Order for productId 195 - Dialectic Moonphase',
-    format: 'array-int',
-    env: 'PRIORITY_POOLS_ORDER_195',
-    default: [1, 23, 22, 2, 5],
-  },
-  customPoolPriorityOrder196: {
-    doc: 'Custom Pool Priority Order for productId 196 - Dialectic Chronograph',
-    format: 'array-int',
-    env: 'PRIORITY_POOLS_ORDER_196',
-    default: [1, 23, 22, 2, 5],
-  },
-  customPoolPriorityOrder227: {
-    doc: 'Custom Pool Priority Order for productId 227 - Base DeFi Pass',
-    format: 'array-int',
-    env: 'PRIORITY_POOLS_ORDER_227',
-    default: [8, 23, 22, 2, 1, 5],
-  },
-  customPoolPriorityOrder233: {
-    doc: 'Custom Pool Priority Order for productId 233 - Relative Finance',
-    format: 'array-int',
-    env: 'PRIORITY_POOLS_ORDER_233',
-    default: [22, 2, 1, 23],
+  customPriorityPoolsOrder: {
+    doc: 'Custom Priority Pools Order for products',
+    format: Object,
+    default: {},
   },
 });
+
+// Automatically detect and add PRIORITY_POOLS_ORDER environment variables
+const envVars = process.env;
+for (const [key, value] of Object.entries(envVars)) {
+  if (key.startsWith('PRIORITY_POOLS_ORDER_')) {
+    const productId = key.split('_').pop();
+    // Convert string array to array of integers with validation
+    const intArray = value.split(',').map((num, index) => {
+      const parsed = parseInt(num.trim(), 10);
+      if (isNaN(parsed)) {
+        throw new Error(`Invalid integer in PRIORITY_POOLS_ORDER_${productId} at index ${index}: ${num}`);
+      }
+      return parsed;
+    });
+    config.set(`customPriorityPoolsOrder.${productId}`, intArray);
+  }
+}
 
 config.validate({ allowed: 'strict' });
 

--- a/src/store/reducer.js
+++ b/src/store/reducer.js
@@ -20,16 +20,15 @@ const initialState = {
   poolProducts: {}, // {productId}_{poolId} -> { allocations, trancheCapacities }
   productPoolIds: {}, // productId -> [ poolIds ]
   products: {}, // productId -> { product }
-  productPriorityPoolsFixedPrice: {
-    // NOTE: only fixed price products are currently supported
-    186: config.get('customPoolPriorityOrder186'), // DeltaPrime (UnoRe)
-    195: config.get('customPoolPriorityOrder195'), // Dialectic Moonphase
-    196: config.get('customPoolPriorityOrder196'), // Dialectic Chronograph
-    227: config.get('customPoolPriorityOrder227'), // Base DeFi Pass
-    233: config.get('customPoolPriorityOrder233'), // Relative Finance
-  },
+  productPriorityPoolsFixedPrice: {},
   trancheId: 0,
 };
+
+// Automatically populate productPriorityPoolsFixedPrice
+const customPriorityPoolsOrder = config.get('customPriorityPoolsOrder') || {};
+for (const [productId, orderArray] of Object.entries(customPriorityPoolsOrder)) {
+  initialState.productPriorityPoolsFixedPrice[productId] = orderArray;
+}
 
 function reducer(state = initialState, { type, payload }) {
   if (type === SET_PRODUCT) {

--- a/test/mocks/store.js
+++ b/test/mocks/store.js
@@ -1,5 +1,10 @@
 const { BigNumber } = require('ethers');
 
+process.env.PRIORITY_POOLS_ORDER_186 = '18,22,1';
+process.env.PRIORITY_POOLS_ORDER_195 = '1,23,22,2,5';
+process.env.PRIORITY_POOLS_ORDER_196 = '1,23,22,2,5';
+
+// require config after setting env variable
 const config = require('../../src/config');
 
 const store = {
@@ -16,7 +21,7 @@ const store = {
     255: { id: 255, symbol: 'NXM', decimals: 18 },
   },
   productPriorityPoolsFixedPrice: {
-    4: config.get('customPoolPriorityOrder186'),
+    4: config.get('customPriorityPoolsOrder')[186],
   },
   globalCapacityRatio: BigNumber.from(20000),
   poolProducts: {

--- a/test/mocks/store.js
+++ b/test/mocks/store.js
@@ -3,6 +3,8 @@ const { BigNumber } = require('ethers');
 process.env.PRIORITY_POOLS_ORDER_186 = '18,22,1';
 process.env.PRIORITY_POOLS_ORDER_195 = '1,23,22,2,5';
 process.env.PRIORITY_POOLS_ORDER_196 = '1,23,22,2,5';
+process.env.PRIORITY_POOLS_ORDER_227 = '8,23,22,2,1,5';
+process.env.PRIORITY_POOLS_ORDER_233 = '22,2,1,23';
 
 // require config after setting env variable
 const config = require('../../src/config');

--- a/test/unit/reducer.js
+++ b/test/unit/reducer.js
@@ -1,0 +1,38 @@
+const { expect } = require('chai');
+
+describe('productPriorityPoolsFixedPrice state', () => {
+  let originalEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    // Restore the original environment variables
+    process.env = originalEnv;
+    // Clear the require cache to ensure fresh imports in each test
+    delete require.cache[require.resolve('../../src/config')];
+    delete require.cache[require.resolve('../../src/store/reducer')];
+  });
+
+  it('should populate initialState.productPriorityPoolsFixedPrice with valid arrays of integers', () => {
+    process.env.PRIORITY_POOLS_ORDER_186 = '18,22,1';
+    process.env.PRIORITY_POOLS_ORDER_195 = '1,23,22,2,5';
+    process.env.PRIORITY_POOLS_ORDER_196 = '1,23,22,2,5';
+
+    // Import modules after setting environment variables
+    const { initialState } = require('../../src/store/reducer');
+
+    expect(initialState.productPriorityPoolsFixedPrice['186']).to.deep.equal([18, 22, 1]);
+    expect(initialState.productPriorityPoolsFixedPrice['195']).to.deep.equal([1, 23, 22, 2, 5]);
+    expect(initialState.productPriorityPoolsFixedPrice['196']).to.deep.equal([1, 23, 22, 2, 5]);
+  });
+
+  it('should throw an error for invalid custom priority pools order values', () => {
+    process.env.PRIORITY_POOLS_ORDER_186 = '18,22,invalid,1';
+
+    expect(() => {
+      require('../../src/config');
+    }).to.throw('Invalid integer in PRIORITY_POOLS_ORDER_186 at index 2: invalid');
+  });
+});

--- a/test/unit/reducer.js
+++ b/test/unit/reducer.js
@@ -16,16 +16,17 @@ describe('productPriorityPoolsFixedPrice state', () => {
   });
 
   it('should populate initialState.productPriorityPoolsFixedPrice with valid arrays of integers', () => {
-    process.env.PRIORITY_POOLS_ORDER_186 = '18,22,1';
-    process.env.PRIORITY_POOLS_ORDER_195 = '1,23,22,2,5';
-    process.env.PRIORITY_POOLS_ORDER_196 = '1,23,22,2,5';
+    // NOTE: the env vars are set in the mocks/store.js file
 
-    // Import modules after setting environment variables
+    // Import modules after environment variables are set
     const { initialState } = require('../../src/store/reducer');
 
+    // Updated expectations for productPriorityPoolsFixedPrice
     expect(initialState.productPriorityPoolsFixedPrice['186']).to.deep.equal([18, 22, 1]);
     expect(initialState.productPriorityPoolsFixedPrice['195']).to.deep.equal([1, 23, 22, 2, 5]);
     expect(initialState.productPriorityPoolsFixedPrice['196']).to.deep.equal([1, 23, 22, 2, 5]);
+    expect(initialState.productPriorityPoolsFixedPrice['227']).to.deep.equal([8, 23, 22, 2, 1, 5]);
+    expect(initialState.productPriorityPoolsFixedPrice['233']).to.deep.equal([22, 2, 1, 23]);
   });
 
   it('should throw an error for invalid custom priority pools order values', () => {


### PR DESCRIPTION
## Context

Closes #126

Currently when adding custom priority pool env vars `PRIORITY_POOLS_ORDER_XXX` we need to also manually add code to read these and apply them.

This change removes that manual step so we can just add the new custom priority pools env vars and restart the service (reading, parsing and applying of these env vars will be done automatically)

## Changes proposed in this pull request

* auto read, parse and apply of custom priority pools order env vars

## Test plan

* added unit tests

## Checklist

- [x] Rebased the base branch
- [x] Attached corresponding Github issue
- [x] Prefixed the name with the type of change (i.e. feat, chore, test)
- [x] Performed a self-review of my own code
- [x] Followed the style guidelines of this project
- [ ] Made corresponding changes to the documentation
- [x] Didn't generate new warnings
- [x] Didn't generate failures on existing tests
- [x] Added tests that prove my fix is effective or that my feature works


## Review

When reviewing a PR, please indicate intention in comments using the following emojis:
* :cake: = Nice to have but not essential.
* :bulb: = Suggestion or a comment based on personal opinion
* :hammer: = I believe this should be changed.
* :thinking: = I don’t understand something, do you mind giving me more context?
* :rocket: = Feedback
