### PR TITLE
chore: remove trivy scan from the ci

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -35,20 +35,6 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci --ignore-scripts
 
-  scan:
-    runs-on: ubuntu-22.04
-    name: Scan
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Scan
-        run: |
-          export TRIVY_VERSION="0.54.1"
-          wget --no-verbose https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz -O - | tar -zxvf -
-          echo "Scanning filesystem"
-          ./trivy filesystem .
-
   lint:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
@@ -168,7 +154,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/dev'
-    needs: ["setup", "test", "lint", "scan", "build_and_push"]
+    needs: ["setup", "test", "lint", "build_and_push"]
     steps:
       - name: Set Env
         run: |


### PR DESCRIPTION
## Description

The CI scan step is erroring out too often and it's not required as we're using GH's dependabot.

## Testing

N/A.

## Checklist

- [x] Performed a self-review of my own code
- [x] Made corresponding changes to the documentation
