### PR TITLE
feat: add new field capacityPerPool to capacity pool API

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ best available combination of pools for the premium.
 - **URL**: `/v2/capacity/{productId}`
 - **Method**: `GET`
 - **OpenAPI**: [v2/api/docs/#/Capacity/get_v2_capacity__productId_](https://api.nexusmutual.io/v2/api/docs/#/Capacity/get_v2_capacity__productId_)
-- **Description**: Returns the current capacity for a specific product for a period of 30 days if no period query param is specified.
+- **Description**: Returns the current capacity for a specific product for a period of 30 days if no period query param is specified. Additionally, if the query parameter `withPools=true` is provided, the response will include the `capacityPerPool` field with detailed capacity information per pool.
 
 ### Capacity Route for all products in a pool
 - **URL**: `/v2/capacity/pools/{poolId}`

--- a/src/lib/capacityEngine.js
+++ b/src/lib/capacityEngine.js
@@ -124,6 +124,7 @@ function calculateProductDataForTranche(productPools, firstUsableTrancheIndex, u
     }
     aggregatedData.totalPremium = aggregatedData.totalPremium.add(poolPremium);
 
+    // The available capacity of a product for a particular pool
     const availableCapacityInAssets = Object.keys(assets).map(assetId => ({
       assetId: Number(assetId),
       amount: availableInNXM.mul(assetRates[assetId]).div(WeiPerEther),
@@ -264,6 +265,7 @@ function capacityEngine(store, { poolId = null, productIds = [], period = 30, wi
     }
 
     const { capacityAvailableNXM, capacityUsedNXM, minPrice } = aggregatedData;
+    // The available capacity of a product across all pools
     const capacityInAssets = Object.keys(assets).map(assetId => ({
       assetId: Number(assetId),
       amount: capacityAvailableNXM.mul(assetRates[assetId]).div(WeiPerEther),

--- a/src/routes/capacity.js
+++ b/src/routes/capacity.js
@@ -66,9 +66,12 @@ router.get(
     try {
       const period = BigNumber.from(periodQuery);
       const store = req.app.get('store');
-      const response = capacityEngine(store, { period });
+      const capacities = capacityEngine(store, { period });
 
-      res.json(response.map(capacity => formatCapacityResult(capacity)));
+      const response = capacities.map(capacity => formatCapacityResult(capacity));
+      console.log(inspect(capacities, { depth: null }));
+
+      res.json(response);
     } catch (error) {
       console.error(error);
       return res.status(500).send({ error: 'Internal Server Error', response: null });
@@ -108,6 +111,7 @@ router.get(
   asyncRoute(async (req, res) => {
     const productId = Number(req.params.productId);
     const periodQuery = Number(req.query.period) || 30;
+    const withPools = req.query.withPools === 'true';
 
     if (!Number.isInteger(periodQuery) || periodQuery < 28 || periodQuery > 365) {
       return res.status(400).send({ error: 'Invalid period: must be an integer between 28 and 365', response: null });
@@ -119,13 +123,16 @@ router.get(
     try {
       const period = BigNumber.from(periodQuery);
       const store = req.app.get('store');
-      const [capacity] = capacityEngine(store, { productIds: [productId], period });
+      const [capacity] = capacityEngine(store, { productIds: [productId], period, withPools });
 
       if (!capacity) {
         return res.status(400).send({ error: 'Invalid Product Id', response: null });
       }
 
-      res.json(formatCapacityResult(capacity));
+      const response = formatCapacityResult(capacity);
+      console.log(inspect(response, { depth: null }));
+
+      res.json(response);
     } catch (error) {
       console.error(error);
       return res.status(500).send({ error: 'Internal Server Error', response: null });
@@ -188,13 +195,16 @@ router.get(
     try {
       const period = BigNumber.from(periodQuery);
       const store = req.app.get('store');
-      const response = capacityEngine(store, { poolId, period });
+      const capacities = capacityEngine(store, { poolId, period });
 
-      if (response.length === 0) {
+      if (capacities.length === 0) {
         return res.status(404).send({ error: 'Pool not found', response: null });
       }
 
-      res.json(response.map(capacity => formatCapacityResult(capacity)));
+      const response = capacities.map(capacity => formatCapacityResult(capacity));
+      console.log(inspect(response, { depth: null }));
+
+      res.json(response);
     } catch (error) {
       console.error(error);
       return res.status(500).send({ error: 'Internal Server Error', response: null });
@@ -265,10 +275,15 @@ router.get(
       const period = BigNumber.from(periodQuery);
       const store = req.app.get('store');
       const [capacity] = capacityEngine(store, { poolId, productIds: [productId], period });
+
       if (!capacity) {
         return res.status(404).send({ error: 'Product not found in the specified pool', response: null });
       }
-      res.json(formatCapacityResult(capacity));
+
+      const response = formatCapacityResult(capacity);
+      console.log(inspect(response, { depth: null }));
+
+      res.json(response);
     } catch (error) {
       console.error(error);
       return res.status(500).send({ error: 'Internal Server Error', response: null });

--- a/src/routes/capacity.js
+++ b/src/routes/capacity.js
@@ -93,13 +93,80 @@ router.get(
  *       schema:
  *         type: integer
  *         description: The product id
+ *     - in: query
+ *       name: withPools
+ *       required: false
+ *       schema:
+ *         type: boolean
+ *         default: false
+ *         description: When true, includes `capacityPerPool` field in the response
  *     responses:
  *       200:
- *         description: Returns capacity data for a product
+ *         description: Returns capacity data for a product. If withPools=true, includes capacityPerPool data.
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/CapacityResult'
+ *               oneOf:
+ *                 - $ref: '#/components/schemas/CapacityResult'
+ *                 - $ref: '#/components/schemas/CapacityResultWithPools'
+ *             examples:
+ *               withoutPools:
+ *                 summary: Response when withPools=false
+ *                 value:
+ *                   productId: 1
+ *                   availableCapacity: [
+ *                     {
+ *                       assetId: 1,
+ *                       amount: "1000000000000000000",
+ *                       asset: {
+ *                         id: 1,
+ *                         symbol: "ETH",
+ *                         decimals: 18
+ *                       }
+ *                     }
+ *                   ]
+ *                   allocatedNxm: "500000000000000000"
+ *                   utilizationRate: 5000
+ *                   minAnnualPrice: "0.025"
+ *                   maxAnnualPrice: "0.1"
+ *               withPools:
+ *                 summary: Response when withPools=true
+ *                 value:
+ *                   productId: 1
+ *                   availableCapacity: [
+ *                     {
+ *                       assetId: 1,
+ *                       amount: "1000000000000000000",
+ *                       asset: {
+ *                         id: 1,
+ *                         symbol: "ETH",
+ *                         decimals: 18
+ *                       }
+ *                     }
+ *                   ]
+ *                   allocatedNxm: "500000000000000000"
+ *                   utilizationRate: 5000
+ *                   minAnnualPrice: "0.025"
+ *                   maxAnnualPrice: "0.1"
+ *                   capacityPerPool: [
+ *                     {
+ *                       poolId: 1,
+ *                       availableCapacity: [
+ *                         {
+ *                           assetId: 1,
+ *                           amount: "500000000000000000",
+ *                           asset: {
+ *                             id: 1,
+ *                             symbol: "ETH",
+ *                             decimals: 18
+ *                           }
+ *                         }
+ *                       ],
+ *                       allocatedNxm: "250000000000000000",
+ *                       minAnnualPrice: "0.025",
+ *                       maxAnnualPrice: "0.1"
+ *                     }
+ *                   ]
  *       400:
  *         description: Invalid productId or period
  *       500:
@@ -321,59 +388,54 @@ router.get(
  *           description: The capacity amount expressed in the asset
  *         asset:
  *           $ref: '#/components/schemas/AssetInfo'
+ *     BaseCapacityFields:
+ *       type: object
+ *       properties:
+ *         availableCapacity:
+ *           type: array
+ *           description: The maximum available capacity.
+ *           items:
+ *             $ref: '#/components/schemas/AvailableCapacity'
+ *         allocatedNxm:
+ *           type: string
+ *           format: integer
+ *           description: The used capacity amount for active covers.
+ *         minAnnualPrice:
+ *           type: string
+ *           description: The minimal annual price is a percentage value between 0-1.
+ *         maxAnnualPrice:
+ *           type: string
+ *           description: The maximal annual price is a percentage value between 0-1.
  *     PoolCapacity:
- *       type: object
- *       properties:
- *         poolId:
- *           type: integer
- *           description: The pool id
- *         availableCapacity:
- *           type: array
- *           description: The maximum available capacity for the pool's product.
- *           items:
- *             $ref: '#/components/schemas/AvailableCapacity'
- *         allocatedNxm:
- *           type: string
- *           format: integer
- *           description: The used capacity amount for active covers on the pool.
- *         minAnnualPrice:
- *           type: string
- *           description: The minimal annual price is a percentage value between 0-1.
- *         maxAnnualPrice:
- *           type: string
- *           description: The maximal annual price is a percentage value between 0-1.
+ *       allOf:
+ *         - $ref: '#/components/schemas/BaseCapacityFields'
+ *         - type: object
+ *           properties:
+ *             poolId:
+ *               type: integer
+ *               description: The pool id
  *     CapacityResult:
- *       type: object
- *       properties:
- *         productId:
- *           type: integer
- *           description: The product id
- *         availableCapacity:
- *           type: array
- *           description: The maximum available capacity for the product.
- *           items:
- *             $ref: '#/components/schemas/AvailableCapacity'
- *         allocatedNxm:
- *           type: string
- *           format: integer
- *           description: The used capacity amount for active covers on the product.
- *         utilizationRate:
- *           type: number
- *           format: integer
- *           description: The percentage of used capacity to total capacity, expressed as basis points (0-10,000).
- *         minAnnualPrice:
- *           type: string
- *           description: The minimal annual price is a percentage value between 0-1.
- *         maxAnnualPrice:
- *           type: string
- *           description: The maximal annual price is a percentage value between 0-1.
- *         capacityPerPool:
- *           type: array
- *           description: >-
- *             The capacity per pool. This field is only included when the query parameter `withPools=true`.
- *             If `withPools` is false or not provided, this field will be undefined and not present in the response.
- *           items:
- *             $ref: '#/components/schemas/PoolCapacity'
+ *       allOf:
+ *         - $ref: '#/components/schemas/BaseCapacityFields'
+ *         - type: object
+ *           properties:
+ *             productId:
+ *               type: integer
+ *               description: The product id
+ *             utilizationRate:
+ *               type: number
+ *               format: integer
+ *               description: The percentage of used capacity to total capacity, expressed as basis points (0-10,000).
+ *     CapacityResultWithPools:
+ *       allOf:
+ *         - $ref: '#/components/schemas/CapacityResult'
+ *         - type: object
+ *           properties:
+ *             capacityPerPool:
+ *               type: array
+ *               description: The capacity per pool.
+ *               items:
+ *                 $ref: '#/components/schemas/PoolCapacity'
  */
 
 module.exports = router;

--- a/src/routes/capacity.js
+++ b/src/routes/capacity.js
@@ -1,3 +1,5 @@
+const { inspect } = require('node:util');
+
 const { ethers, BigNumber } = require('ethers');
 const express = require('express');
 
@@ -18,6 +20,17 @@ const formatCapacityResult = capacity => ({
   utilizationRate: capacity.utilizationRate.toNumber(),
   minAnnualPrice: formatUnits(capacity.minAnnualPrice),
   maxAnnualPrice: formatUnits(capacity.maxAnnualPrice),
+  capacityPerPool: capacity.capacityPerPool?.map(c => ({
+    poolId: c.poolId,
+    availableCapacity: c.availableCapacity.map(({ assetId, amount, asset }) => ({
+      assetId,
+      amount: amount.toString(),
+      asset,
+    })),
+    allocatedNxm: c.allocatedNxm.toString(),
+    minAnnualPrice: formatUnits(c.minAnnualPrice),
+    maxAnnualPrice: formatUnits(c.maxAnnualPrice),
+  })),
 });
 
 /**

--- a/src/routes/capacity.js
+++ b/src/routes/capacity.js
@@ -295,6 +295,53 @@ router.get(
  * @openapi
  * components:
  *   schemas:
+ *     AssetInfo:
+ *       type: object
+ *       description: An object containing asset info
+ *       properties:
+ *         id:
+ *           type: integer
+ *           description: The id of the asset
+ *         symbol:
+ *           type: string
+ *           description: The symbol of the asset
+ *         decimals:
+ *           type: integer
+ *           description: The decimals of the asset
+ *           example: 18
+ *     AvailableCapacity:
+ *       type: object
+ *       properties:
+ *         assetId:
+ *           type: integer
+ *           description: The asset id
+ *         amount:
+ *           type: string
+ *           format: integer
+ *           description: The capacity amount expressed in the asset
+ *         asset:
+ *           $ref: '#/components/schemas/AssetInfo'
+ *     PoolCapacity:
+ *       type: object
+ *       properties:
+ *         poolId:
+ *           type: integer
+ *           description: The pool id
+ *         availableCapacity:
+ *           type: array
+ *           description: The maximum available capacity for the pool's product.
+ *           items:
+ *             $ref: '#/components/schemas/AvailableCapacity'
+ *         allocatedNxm:
+ *           type: string
+ *           format: integer
+ *           description: The used capacity amount for active covers on the pool.
+ *         minAnnualPrice:
+ *           type: string
+ *           description: The minimal annual price is a percentage value between 0-1.
+ *         maxAnnualPrice:
+ *           type: string
+ *           description: The maximal annual price is a percentage value between 0-1.
  *     CapacityResult:
  *       type: object
  *       properties:
@@ -305,29 +352,7 @@ router.get(
  *           type: array
  *           description: The maximum available capacity for the product.
  *           items:
- *             type: object
- *             properties:
- *               assetId:
- *                 type: integer
- *                 description: The asset id
- *               amount:
- *                 type: string
- *                 format: integer
- *                 description: The capacity amount expressed in the asset
- *               asset:
- *                 type: object
- *                 description: An object containing asset info
- *                 properties:
- *                   id:
- *                     type: integer
- *                     description: The id of the asset
- *                   symbol:
- *                     type: string
- *                     description: The symbol of the asset
- *                   decimals:
- *                     type: integer
- *                     description: The decimals of the asset
- *                     example: 18
+ *             $ref: '#/components/schemas/AvailableCapacity'
  *         allocatedNxm:
  *           type: string
  *           format: integer
@@ -342,6 +367,13 @@ router.get(
  *         maxAnnualPrice:
  *           type: string
  *           description: The maximal annual price is a percentage value between 0-1.
+ *         capacityPerPool:
+ *           type: array
+ *           description: >-
+ *             The capacity per pool. This field is only included when the query parameter `withPools=true`.
+ *             If `withPools` is false or not provided, this field will be undefined and not present in the response.
+ *           items:
+ *             $ref: '#/components/schemas/PoolCapacity'
  */
 
 module.exports = router;

--- a/test/unit/capacityEngine.js
+++ b/test/unit/capacityEngine.js
@@ -3,13 +3,23 @@ const ethers = require('ethers');
 const sinon = require('sinon');
 
 const { capacities, poolProductCapacities } = require('./responses');
-const { capacityEngine, getUtilizationRate } = require('../../src/lib/capacityEngine'); // Import the function to test
+const {
+  capacityEngine,
+  getUtilizationRate,
+  calculateAvailableCapacity,
+  calculateProductDataForTranche,
+  getProductsInPool,
+  calculateTrancheInfo,
+} = require('../../src/lib/capacityEngine');
+const { NXM_PER_ALLOCATION_UNIT } = require('../../src/lib/constants');
+const { calculateTrancheId, bnMax } = require('../../src/lib/helpers');
 const { selectAsset } = require('../../src/store/selectors');
 const mockStore = require('../mocks/store');
 
 const { BigNumber } = ethers;
 const { parseEther } = ethers.utils;
 const { Zero } = ethers.constants;
+const { assets, assetRates } = mockStore;
 
 describe('Capacity Engine tests', function () {
   describe('capacityEngine', function () {
@@ -179,6 +189,61 @@ describe('Capacity Engine tests', function () {
       expect(product.productId).to.equal(Number(nonFixedPricedProductId));
       expect(product.minAnnualPrice).to.not.deep.equal(product.maxAnnualPrice);
     });
+
+    it('should not include capacityPerPool when withPools is false', function () {
+      const productId = '0';
+      const [productWithoutPools] = capacityEngine(store, { productIds: [productId], withPools: false });
+      expect(productWithoutPools).to.not.have.property('capacityPerPool');
+    });
+
+    it('should include capacityPerPool if query param withPool=true', function () {
+      const productId = '0';
+
+      const [productWithPools] = capacityEngine(store, { productIds: [productId], withPools: true });
+      expect(productWithPools).to.have.property('capacityPerPool');
+
+      // Sum up values from capacityPerPool
+      const initCapacity = { usedCapacity: Zero, availableCapacity: {}, minAnnualPrice: Zero, maxAnnualPrice: Zero };
+      const summedCapacity = productWithPools.capacityPerPool.reduce((acc, pool) => {
+        acc.usedCapacity = acc.usedCapacity.add(pool.allocatedNxm);
+        acc.maxAnnualPrice = bnMax(acc.maxAnnualPrice, pool.maxAnnualPrice);
+
+        // skip poolId 3 as there is 0 available capacity
+        if (pool.poolId !== 3 && (acc.minAnnualPrice.isZero() || pool.minAnnualPrice.lt(acc.minAnnualPrice))) {
+          acc.minAnnualPrice = pool.minAnnualPrice;
+        }
+
+        pool.availableCapacity.forEach(asset => {
+          acc.availableCapacity[asset.assetId] = (acc.availableCapacity[asset.assetId] ?? Zero).add(asset.amount);
+        });
+
+        return acc;
+      }, initCapacity);
+
+      // Compare summed values with root-level (across all pools) values
+      expect(summedCapacity.usedCapacity.toString()).to.equal(productWithPools.usedCapacity.toString());
+      expect(summedCapacity.minAnnualPrice.toString()).to.equal(productWithPools.minAnnualPrice.toString());
+      expect(summedCapacity.maxAnnualPrice.toString()).to.equal(productWithPools.maxAnnualPrice.toString());
+
+      productWithPools.availableCapacity.forEach(asset => {
+        expect(summedCapacity.availableCapacity[asset.assetId].toString()).to.equal(asset.amount.toString());
+      });
+    });
+
+    it('should have root-level (across all pools) prices within range of pool prices', function () {
+      const productId = '0';
+      const [productWithPools] = capacityEngine(store, { productIds: [productId], withPools: true });
+
+      const poolPrices = productWithPools.capacityPerPool
+        .filter(pool => pool.poolId !== 3) // skip poolId 3 as there is 0 available capacity
+        .map(pool => ({
+          min: pool.minAnnualPrice,
+          max: pool.maxAnnualPrice,
+        }));
+
+      expect(productWithPools.minAnnualPrice.toString()).to.equal(Math.min(...poolPrices.map(p => p.min)).toString());
+      expect(productWithPools.maxAnnualPrice.toString()).to.equal(Math.max(...poolPrices.map(p => p.max)).toString());
+    });
   });
 
   describe('getUtilizationRate tests', function () {
@@ -218,6 +283,319 @@ describe('Capacity Engine tests', function () {
       const utilizationRate = getUtilizationRate(capacityAvailableNXM, capacityUsedNXM);
 
       expect(utilizationRate.toNumber()).to.equal(0);
+    });
+  });
+
+  describe('calculateAvailableCapacity', function () {
+    it('should calculate available capacity correctly when all tranches are usable', function () {
+      const trancheCapacities = [BigNumber.from(100), BigNumber.from(200), BigNumber.from(300)];
+      const allocations = [BigNumber.from(50), BigNumber.from(100), BigNumber.from(150)];
+      const firstUsableTrancheIndex = 0;
+
+      const result = calculateAvailableCapacity(trancheCapacities, allocations, firstUsableTrancheIndex);
+
+      expect(result.toString()).to.equal('300'); // (100-50) + (200-100) + (300-150) = 300
+    });
+
+    it('should handle unusable tranches correctly', function () {
+      const trancheCapacities = [BigNumber.from(100), BigNumber.from(200), BigNumber.from(300)];
+      const allocations = [BigNumber.from(50), BigNumber.from(100), BigNumber.from(150)];
+      const firstUsableTrancheIndex = 1;
+
+      const result = calculateAvailableCapacity(trancheCapacities, allocations, firstUsableTrancheIndex);
+
+      expect(result.toString()).to.equal('250'); // 0 + (200-100) + (300-150) = 250
+    });
+
+    it('should carry over negative values on unusable tranches', function () {
+      const trancheCapacities = [BigNumber.from(100), BigNumber.from(200), BigNumber.from(300)];
+      const allocations = [BigNumber.from(150), BigNumber.from(100), BigNumber.from(150)];
+      const firstUsableTrancheIndex = 1;
+
+      const result = calculateAvailableCapacity(trancheCapacities, allocations, firstUsableTrancheIndex);
+
+      expect(result.toString()).to.equal('200'); // -50 + (200-100) + (300-150) = 200
+    });
+
+    it('should return zero when all capacity is allocated', function () {
+      const trancheCapacities = [BigNumber.from(100), BigNumber.from(200)];
+      const allocations = [BigNumber.from(100), BigNumber.from(200)];
+      const firstUsableTrancheIndex = 0;
+
+      const result = calculateAvailableCapacity(trancheCapacities, allocations, firstUsableTrancheIndex);
+
+      expect(result.toString()).to.equal('0');
+    });
+
+    it('should handle empty arrays', function () {
+      const trancheCapacities = [];
+      const allocations = [];
+      const firstUsableTrancheIndex = 0;
+
+      const result = calculateAvailableCapacity(trancheCapacities, allocations, firstUsableTrancheIndex);
+
+      expect(result.toString()).to.equal('0');
+    });
+
+    it('should handle case where allocations exceed capacities', function () {
+      const trancheCapacities = [BigNumber.from(100), BigNumber.from(200)];
+      const allocations = [BigNumber.from(150), BigNumber.from(250)];
+      const firstUsableTrancheIndex = 0;
+
+      const result = calculateAvailableCapacity(trancheCapacities, allocations, firstUsableTrancheIndex);
+
+      expect(result.toString()).to.equal('0');
+    });
+  });
+
+  describe('calculateProductDataForTranche', function () {
+    const now = BigNumber.from(1000);
+
+    function assertAvailableCapacity(capacityPool, availableInNXM) {
+      expect(capacityPool.availableCapacity).to.be.an('array');
+      expect(capacityPool.availableCapacity).to.have.lengthOf(Object.keys(assets).length);
+
+      Object.keys(assets).forEach((assetId, index) => {
+        const expectedAmount = availableInNXM.mul(assetRates[assetId]).div(BigNumber.from(10).pow(18));
+        expect(capacityPool.availableCapacity[index].assetId).to.equal(Number(assetId));
+        expect(capacityPool.availableCapacity[index].amount.toString()).to.equal(expectedAmount.toString());
+        expect(capacityPool.availableCapacity[index].asset).to.deep.equal(assets[assetId]);
+      });
+    }
+
+    it('should calculate product data correctly for fixed price', function () {
+      const product2Pool1 = [mockStore.poolProducts['2_1']]; // Product 2 uses fixed price
+      const firstUsableTrancheIndex = 0;
+      const [{ allocations, trancheCapacities }] = product2Pool1;
+
+      const { aggregatedData, capacityPerPool } = calculateProductDataForTranche(
+        product2Pool1,
+        firstUsableTrancheIndex,
+        mockStore.products['2'].useFixedPrice,
+        now,
+        assets,
+        assetRates,
+      );
+
+      const [capacityPool] = capacityPerPool;
+      const lastIndex = allocations.length - 1;
+
+      expect(aggregatedData.capacityUsedNXM.toString()).to.equal(allocations[lastIndex].toString());
+      expect(aggregatedData.capacityAvailableNXM.toString()).to.equal(
+        trancheCapacities[lastIndex].sub(allocations[lastIndex]).mul(NXM_PER_ALLOCATION_UNIT).toString(),
+      );
+
+      expect(capacityPerPool).to.have.lengthOf(1);
+      expect(capacityPool.poolId).to.equal(1);
+      expect(capacityPool.minAnnualPrice.toString()).to.equal(capacityPool.maxAnnualPrice.toString());
+      expect(capacityPool.allocatedNxm.toString()).to.equal(allocations[lastIndex].toString());
+
+      const availableInNXM = trancheCapacities[lastIndex].sub(allocations[lastIndex]).mul(NXM_PER_ALLOCATION_UNIT);
+      assertAvailableCapacity(capacityPool, availableInNXM);
+    });
+
+    it('should calculate product data correctly for non-fixed price', function () {
+      const product0Pool1 = [mockStore.poolProducts['0_1']]; // Product 0 doesn't use fixed price
+      const firstUsableTrancheIndex = 0;
+      const [{ allocations, trancheCapacities }] = product0Pool1;
+
+      const { aggregatedData, capacityPerPool } = calculateProductDataForTranche(
+        product0Pool1,
+        firstUsableTrancheIndex,
+        mockStore.products['0'].useFixedPrice,
+        now,
+        assets,
+        assetRates,
+      );
+
+      const [pool1Capacity] = capacityPerPool;
+      const lastIndex = allocations.length - 1;
+
+      expect(aggregatedData.capacityUsedNXM.toString()).to.equal(allocations[lastIndex].toString());
+      expect(aggregatedData.capacityAvailableNXM.toString()).to.equal(
+        trancheCapacities[lastIndex].sub(allocations[lastIndex]).mul(NXM_PER_ALLOCATION_UNIT).toString(),
+      );
+      expect(capacityPerPool).to.have.lengthOf(1);
+      expect(pool1Capacity.poolId).to.equal(1);
+      expect(pool1Capacity.minAnnualPrice.toString()).to.not.equal(pool1Capacity.maxAnnualPrice.toString());
+
+      const availableInNXM = trancheCapacities[lastIndex].sub(allocations[lastIndex]).mul(NXM_PER_ALLOCATION_UNIT);
+      assertAvailableCapacity(pool1Capacity, availableInNXM);
+    });
+
+    it('should handle zero available capacity', function () {
+      const productPools = [
+        {
+          ...mockStore.poolProducts['0_1'],
+          allocations: [...Array(7).fill(Zero), BigNumber.from(9840)],
+          trancheCapacities: [...Array(7).fill(Zero), BigNumber.from(9840)],
+        },
+      ];
+      const firstUsableTrancheIndex = 0;
+
+      const { aggregatedData, capacityPerPool } = calculateProductDataForTranche(
+        productPools,
+        firstUsableTrancheIndex,
+        mockStore.products['0'].useFixedPrice,
+        now,
+        assets,
+        assetRates,
+      );
+
+      const [pool1Capacity] = capacityPerPool;
+
+      expect(aggregatedData.capacityAvailableNXM.toString()).to.equal('0');
+      expect(pool1Capacity.availableCapacity).to.deep.equal([]);
+      expect(pool1Capacity.minAnnualPrice.toString()).to.equal('0');
+      expect(pool1Capacity.maxAnnualPrice.toString()).to.equal('0');
+    });
+
+    it('should calculate product data correctly for multiple pools of the same product', function () {
+      const productPools = [mockStore.poolProducts['0_1'], mockStore.poolProducts['0_2']];
+      const firstUsableTrancheIndex = 0;
+
+      const { aggregatedData, capacityPerPool } = calculateProductDataForTranche(
+        productPools,
+        firstUsableTrancheIndex,
+        mockStore.products['0'].useFixedPrice,
+        now,
+        assets,
+        assetRates,
+      );
+
+      expect(capacityPerPool).to.have.lengthOf(2);
+
+      const [pool1Product0, pool2Product0] = productPools;
+      const [pool1Capacity, pool2Capacity] = capacityPerPool;
+
+      const lastIndex1 = pool1Product0.allocations.length - 1;
+      const lastIndex2 = pool2Product0.allocations.length - 1;
+
+      // Check aggregated data
+      expect(aggregatedData.capacityUsedNXM.toString()).to.equal(
+        pool1Product0.allocations[lastIndex1].add(pool2Product0.allocations[lastIndex2]).toString(),
+      );
+      expect(aggregatedData.capacityAvailableNXM.toString()).to.equal(
+        pool1Product0.trancheCapacities[lastIndex1]
+          .sub(pool1Product0.allocations[lastIndex1])
+          .add(pool2Product0.trancheCapacities[lastIndex2].sub(pool2Product0.allocations[lastIndex2]))
+          .mul(NXM_PER_ALLOCATION_UNIT)
+          .toString(),
+      );
+
+      expect(pool1Capacity.poolId).to.equal(1);
+      expect(pool2Capacity.poolId).to.equal(2);
+
+      // Additional checks for each pool
+      capacityPerPool.forEach((poolCapacity, index) => {
+        expect(poolCapacity.minAnnualPrice.toString()).to.not.equal(poolCapacity.maxAnnualPrice.toString());
+        expect(poolCapacity.availableCapacity.length).to.not.equal(0);
+
+        const { allocations, trancheCapacities } = productPools[index];
+        const lastIndex = allocations.length - 1;
+        const availableInNXM = trancheCapacities[lastIndex].sub(allocations[lastIndex]).mul(NXM_PER_ALLOCATION_UNIT);
+        assertAvailableCapacity(poolCapacity, availableInNXM);
+      });
+    });
+  });
+
+  describe('getProductsInPool', function () {
+    let mockStore;
+
+    beforeEach(function () {
+      mockStore = {
+        getState: sinon.stub(),
+      };
+    });
+
+    afterEach(function () {
+      sinon.restore();
+    });
+
+    it('should return correct product IDs for a given pool', function () {
+      mockStore.getState.returns({
+        products: { 1: {}, 2: {}, 3: {} },
+        productPoolIds: { 1: [1, 2], 2: [2], 3: [1, 2] },
+        poolProducts: { '1_2': { poolId: 2 }, '2_2': { poolId: 2 }, '3_2': { poolId: 2 } },
+      });
+
+      const poolId = 2;
+      const result = getProductsInPool(mockStore, poolId);
+
+      expect(result).to.deep.equal(['1', '2', '3']);
+    });
+
+    it('should return an empty array for a pool with no products', function () {
+      mockStore.getState.returns({
+        products: { 1: {}, 2: {}, 3: {} },
+        productPoolIds: { 1: [1], 2: [1], 3: [1] },
+        poolProducts: { '1_1': { poolId: 1 }, '2_1': { poolId: 1 }, '3_1': { poolId: 1 } },
+      });
+
+      const poolId = 2;
+      const result = getProductsInPool(mockStore, poolId);
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it('should handle undefined productPools', function () {
+      mockStore.getState.returns({
+        products: { 1: {}, 2: {}, 3: {} },
+        productPoolIds: {},
+        poolProducts: {},
+      });
+
+      const poolId = 2;
+      const result = getProductsInPool(mockStore, poolId);
+
+      expect(result).to.deep.equal([]);
+    });
+  });
+
+  describe('calculateTrancheInfo', function () {
+    const SECONDS_PER_DAY = BigNumber.from(24 * 3600);
+    const MAX_COVER_PERIOD = BigNumber.from(365 * 24 * 3600);
+
+    it('should calculate tranche indices correctly', function () {
+      const time = BigNumber.from(1000);
+      const product = { gracePeriod: BigNumber.from(86400) }; // 1 day grace period
+      const period = 30; // 30 days coverage period
+
+      const result = calculateTrancheInfo(time, product, period);
+
+      const expectedFirstUsableTrancheIndex =
+        calculateTrancheId(time.add(SECONDS_PER_DAY.mul(period)).add(product.gracePeriod)) - calculateTrancheId(time);
+      const expectedFirstUsableTrancheForMaxPeriodIndex =
+        calculateTrancheId(time.add(MAX_COVER_PERIOD).add(product.gracePeriod)) - calculateTrancheId(time);
+
+      expect(result.firstUsableTrancheIndex).to.equal(expectedFirstUsableTrancheIndex);
+      expect(result.firstUsableTrancheForMaxPeriodIndex).to.equal(expectedFirstUsableTrancheForMaxPeriodIndex);
+    });
+
+    it('should handle maximum period', function () {
+      const time = BigNumber.from(1000);
+      const product = { gracePeriod: BigNumber.from(86400) };
+      const period = 365; // Maximum period
+
+      const result = calculateTrancheInfo(time, product, period);
+
+      expect(result.firstUsableTrancheIndex).to.equal(result.firstUsableTrancheForMaxPeriodIndex);
+    });
+
+    it('should handle very large grace period', function () {
+      const time = BigNumber.from(1000);
+      const product = { gracePeriod: BigNumber.from(365 * 24 * 3600) }; // 1 year grace period
+      const period = 30;
+
+      const result = calculateTrancheInfo(time, product, period);
+
+      const expectedFirstUsableTrancheIndex =
+        calculateTrancheId(time.add(SECONDS_PER_DAY.mul(period)).add(product.gracePeriod)) - calculateTrancheId(time);
+      const expectedFirstUsableTrancheForMaxPeriodIndex =
+        calculateTrancheId(time.add(MAX_COVER_PERIOD).add(product.gracePeriod)) - calculateTrancheId(time);
+
+      expect(result.firstUsableTrancheIndex).to.equal(expectedFirstUsableTrancheIndex);
+      expect(result.firstUsableTrancheForMaxPeriodIndex).to.equal(expectedFirstUsableTrancheForMaxPeriodIndex);
     });
   });
 });

--- a/test/unit/responses.js
+++ b/test/unit/responses.js
@@ -215,6 +215,15 @@ const productCapacityPerPools = {
           assetId: 6,
         },
         {
+          amount: '8095761',
+          asset: {
+            decimals: 8,
+            id: 7,
+            symbol: 'cbBTC',
+          },
+          assetId: 7,
+        },
+        {
           amount: '98400000000000000000',
           asset: {
             decimals: 18,
@@ -257,6 +266,15 @@ const productCapacityPerPools = {
             symbol: 'USDC',
           },
           assetId: 6,
+        },
+        {
+          amount: '30013555',
+          asset: {
+            decimals: 8,
+            id: 7,
+            symbol: 'cbBTC',
+          },
+          assetId: 7,
         },
         {
           amount: '364800000000000000000',

--- a/test/unit/responses.js
+++ b/test/unit/responses.js
@@ -181,6 +181,107 @@ const capacities = [
   },
 ];
 
+const productCapacityPerPools = {
+  // productId 0
+  0: [
+    {
+      allocatedNxm: '0',
+      availableCapacity: [
+        {
+          amount: '1011555965965397760',
+          asset: {
+            decimals: 18,
+            id: 0,
+            symbol: 'ETH',
+          },
+          assetId: 0,
+        },
+        {
+          amount: '2826484798959880487553',
+          asset: {
+            decimals: 18,
+            id: 1,
+            symbol: 'DAI',
+          },
+          assetId: 1,
+        },
+        {
+          amount: '2826484797',
+          asset: {
+            decimals: 6,
+            id: 6,
+            symbol: 'USDC',
+          },
+          assetId: 6,
+        },
+        {
+          amount: '98400000000000000000',
+          asset: {
+            decimals: 18,
+            id: 255,
+            symbol: 'NXM',
+          },
+          assetId: 255,
+        },
+      ],
+      maxAnnualPrice: '0.03',
+      minAnnualPrice: '0.02',
+      poolId: 1,
+    },
+    {
+      allocatedNxm: '0',
+      availableCapacity: [
+        {
+          amount: '3750158703091230720',
+          asset: {
+            decimals: 18,
+            id: 0,
+            symbol: 'ETH',
+          },
+          assetId: 0,
+        },
+        {
+          amount: '10478675352241508148979',
+          asset: {
+            decimals: 18,
+            id: 1,
+            symbol: 'DAI',
+          },
+          assetId: 1,
+        },
+        {
+          amount: '10478675347',
+          asset: {
+            decimals: 6,
+            id: 6,
+            symbol: 'USDC',
+          },
+          assetId: 6,
+        },
+        {
+          amount: '364800000000000000000',
+          asset: {
+            decimals: 18,
+            id: 255,
+            symbol: 'NXM',
+          },
+          assetId: 255,
+        },
+      ],
+      maxAnnualPrice: '0.03',
+      minAnnualPrice: '0.02',
+      poolId: 2,
+    },
+    {
+      allocatedNxm: '364800000000000000000',
+      availableCapacity: [],
+      maxAnnualPrice: '0.0',
+      minAnnualPrice: '0.0',
+      poolId: 3,
+    },
+  ],
+};
+
 // capacities response for product by pool
 const poolProductCapacities = {
   // poolId 2
@@ -381,5 +482,6 @@ module.exports = {
   assets,
   capacities,
   poolProductCapacities,
+  productCapacityPerPools,
   getQuote,
 };

--- a/test/unit/routes/capacity.js
+++ b/test/unit/routes/capacity.js
@@ -35,14 +35,14 @@ describe('Capacity Routes', () => {
   });
 
   describe('GET /capacity/:productId', () => {
-    it('should get all capacities for one product', async function () {
+    it('should get all capacities for the specified productId', async function () {
       const productId = 0;
       const url = `/v2/capacity/${productId}`;
       const { body: response } = await server.get(url).expect('Content-Type', /json/).expect(200);
       expect(response).to.be.deep.equal(capacities[productId]);
     });
 
-    it('should have capacityPerPool if queryParam withPools=true', async function () {
+    it('should have capacityPerPool field if queryParam withPools=true', async function () {
       const productId = 0;
       const url = `/v2/capacity/${productId}?withPools=true`;
       const { body: response } = await server.get(url).expect('Content-Type', /json/).expect(200);
@@ -52,7 +52,6 @@ describe('Capacity Routes', () => {
 
       expect(response).to.be.deep.equal(expectedCapacity);
     });
-    // should get return capacityPerPool if queryParam withPool=true
 
     it('should return 400 Invalid Product Id for non-existent productId', async function () {
       const nonExistentProductId = 999;

--- a/test/unit/routes/capacity.js
+++ b/test/unit/routes/capacity.js
@@ -2,7 +2,7 @@ const { expect } = require('chai');
 const supertest = require('supertest');
 
 const initApp = require('../../mocks/server');
-const { capacities, poolProductCapacities } = require('../responses');
+const { capacities, poolProductCapacities, productCapacityPerPools } = require('../responses');
 
 describe('Capacity Routes', () => {
   let server;
@@ -39,8 +39,20 @@ describe('Capacity Routes', () => {
       const productId = 0;
       const url = `/v2/capacity/${productId}`;
       const { body: response } = await server.get(url).expect('Content-Type', /json/).expect(200);
-      expect(response).to.be.deep.equal(capacities[0]);
+      expect(response).to.be.deep.equal(capacities[productId]);
     });
+
+    it('should have capacityPerPool if queryParam withPools=true', async function () {
+      const productId = 0;
+      const url = `/v2/capacity/${productId}?withPools=true`;
+      const { body: response } = await server.get(url).expect('Content-Type', /json/).expect(200);
+
+      const expectedCapacity = capacities[productId];
+      expectedCapacity.capacityPerPool = productCapacityPerPools[productId];
+
+      expect(response).to.be.deep.equal(expectedCapacity);
+    });
+    // should get return capacityPerPool if queryParam withPool=true
 
     it('should return 400 Invalid Product Id for non-existent productId', async function () {
       const nonExistentProductId = 999;


### PR DESCRIPTION
## Description

Closes https://github.com/NexusMutual/cover-router/issues/131

`/capacity/:pooId`:
* new `capacityPerPool` field object - min/maxAnnualPrice for a product per pool 

NOTE: this PR is behind https://github.com/NexusMutual/cover-router/pull/130

## Testing

unit tests

## Checklist

- [x] Performed a self-review of my own code
- [x] Made corresponding changes to the documentation
