### PR TITLE
refactor: return empty product capacity on pools with no products

### DIFF
--- a/src/lib/capacityEngine.js
+++ b/src/lib/capacityEngine.js
@@ -102,10 +102,12 @@ function calculateProductCapacity(
       );
 
       if (i === firstUsableTrancheIndex) {
+        // use the capacity data on the firstUsableTrancheIndex
         aggregatedData = trancheData;
         capacityPerPool = trancheCapacityPerPool;
       }
 
+      // continue iterating through the tranches to calculate the max annual price
       const { capacityAvailableNXM, totalPremium } = trancheData;
       const maxTrancheAnnualPrice = capacityAvailableNXM.isZero()
         ? Zero
@@ -115,7 +117,8 @@ function calculateProductCapacity(
   }
 
   const { capacityAvailableNXM, capacityUsedNXM, minPrice } = aggregatedData;
-  // The available capacity of a product across all pools
+
+  // The available (i.e. remaining) capacity of a product
   const capacityInAssets = Object.keys(assets).map(assetId => ({
     assetId: Number(assetId),
     amount: capacityAvailableNXM.mul(assetRates[assetId]).div(WeiPerEther),
@@ -190,10 +193,6 @@ function getPoolCapacity(store, poolId, period) {
   const { assets, assetRates } = store.getState();
   const now = BigNumber.from(Date.now()).div(1000);
   const productIds = selectProductsInPool(store, poolId);
-
-  if (productIds.length === 0) {
-    return null;
-  }
 
   const productsCapacity = productIds
     .map(productId =>

--- a/src/routes/capacity.js
+++ b/src/routes/capacity.js
@@ -258,8 +258,6 @@ router.get(
  *               ]
  *       400:
  *         description: Invalid pool id or period
- *       404:
- *         description: Pool not found
  *       500:
  *         description: Internal Server Error
  */

--- a/src/routes/capacity.js
+++ b/src/routes/capacity.js
@@ -281,10 +281,6 @@ router.get(
       const store = req.app.get('store');
       const poolCapacity = getPoolCapacity(store, poolId, period);
 
-      if (poolCapacity === null) {
-        return res.status(404).send({ error: 'Pool not found', response: null });
-      }
-
       const response = {
         poolId: poolCapacity.poolId,
         utilizationRate: poolCapacity.utilizationRate.toNumber(),

--- a/test/unit/routes/capacity.js
+++ b/test/unit/routes/capacity.js
@@ -84,11 +84,24 @@ describe('Capacity Routes', () => {
       expect(response.error).to.be.equal('Invalid period: must be an integer between 28 and 365');
     });
 
-    it('should return 404 Pool not found', async function () {
-      const nonExistentPoolId = 999;
-      const url = `/v2/capacity/pools/${nonExistentPoolId}`;
-      const { body: response } = await server.get(url).expect('Content-Type', /json/).expect(404);
-      expect(response.error).to.be.equal('Pool not found');
+    it('should return empty productsCapacity and zero utilizationRate for pool with no products', async function () {
+      const emptyPoolId = 28;
+      const url = `/v2/capacity/pools/${emptyPoolId}`;
+      const { body: response } = await server.get(url).expect('Content-Type', /json/).expect(200);
+
+      expect(response.poolId).to.equal(emptyPoolId);
+      expect(response.utilizationRate).to.equal(0);
+      expect(response.productsCapacity).to.have.lengthOf(0);
+    });
+
+    it('should return empty productsCapacity and zero utilizationRate for for non-existent poolId', async function () {
+      const invalidPoolId = 28;
+      const url = `/v2/capacity/pools/${invalidPoolId}`;
+      const { body: response } = await server.get(url).expect('Content-Type', /json/).expect(200);
+
+      expect(response.poolId).to.equal(invalidPoolId);
+      expect(response.utilizationRate).to.equal(0);
+      expect(response.productsCapacity).to.have.lengthOf(0);
     });
   });
 


### PR DESCRIPTION
## Description

For pool 28, which has 0 products, `cover-router` currently returns a 404 `PoolId not found`.

This happens because `cover-router` only tracks which poolIds support which products. It doesn’t distinguish between an invalid poolId and a pool with no products, so it responds the same way in both cases.

Given that we have a valid pool (28) with 0 products, and the FE is unlikely to query cover-router with an invalid poolId, it makes sense to adjust the response to better reflect the scenario of pools with no products.

This PR implements those changes.

## Testing

unit tests

## Checklist

- [x] Performed a self-review of my own code
- [x] Made corresponding changes to the documentation
