### PR TITLE
fix: available capacity calculation

### DIFF
--- a/src/lib/capacityEngine.js
+++ b/src/lib/capacityEngine.js
@@ -6,6 +6,7 @@ const {
   calculateTrancheId,
   calculateFirstUsableTrancheIndex,
   calculateProductDataForTranche,
+  getCapacitiesInAssets,
 } = require('./helpers');
 const { selectProduct, selectProductPools, selectProductsInPool } = require('../store/selectors');
 
@@ -119,11 +120,7 @@ function calculateProductCapacity(
   const { capacityAvailableNXM, capacityUsedNXM, minPrice } = aggregatedData;
 
   // The available (i.e. remaining) capacity of a product
-  const capacityInAssets = Object.keys(assets).map(assetId => ({
-    assetId: Number(assetId),
-    amount: capacityAvailableNXM.mul(assetRates[assetId]).div(WeiPerEther),
-    asset: assets[assetId],
-  }));
+  const capacityInAssets = getCapacitiesInAssets(capacityAvailableNXM, assets, assetRates);
 
   const capacityData = {
     productId: Number(productId),

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -158,12 +158,7 @@ function calculateProductDataForTranche(productPools, firstUsableTrancheIndex, u
       ? targetPrice
       : calculateBasePrice(targetPrice, bumpedPrice, bumpedPriceUpdateTime, now);
 
-    // the minimum price depends on the surge
-    // so we buy the smallest possible unit of capacity
-    // and calculate the premium per year
-    const unitPremium = calculatePremiumPerYear(NXM_PER_ALLOCATION_UNIT, basePrice);
-
-    const poolMinPrice = WeiPerEther.mul(unitPremium).div(NXM_PER_ALLOCATION_UNIT);
+    const poolMinPrice = WeiPerEther.mul(basePrice).div(TARGET_PRICE_DENOMINATOR);
 
     // the maximum price a user would get can only be determined if the entire available
     // capacity is bought because the routing will always pick the cheapest

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -78,6 +78,16 @@ const bufferedCapacity = capacityInNxm => {
   return bnMax(capacityInNxm.sub(capacityBuffer), Zero);
 };
 
+/**
+ * Calculates the available capacity in NXM across all trancehs.
+ * Buffer is applied because using capacity up to the limit may lead to reverted transactions
+ * in the cases of small price changes of cover assets.
+ *
+ * @param {Array<BigNumber>} trancheCapacities - An array of tranche capacities
+ * @param {Array<BigNumber>} allocations - An array of allocated amounts corresponding to each tranche
+ * @param {number} firstUsableTrancheIndex - The index of the first usable tranche
+ * @returns {BigNumber} The available capacity in NXM, adjusted with buffering
+ */
 function calculateAvailableCapacityInNXM(trancheCapacities, allocations, firstUsableTrancheIndex) {
   const unused = trancheCapacities.reduce((available, capacity, index) => {
     const allocationDifference = capacity.sub(allocations[index]);

--- a/src/lib/quoteEngine.js
+++ b/src/lib/quoteEngine.js
@@ -21,7 +21,8 @@ const { WeiPerEther } = ethers.constants;
 const { formatEther } = ethers.utils;
 
 /**
- * This function allocates the requested amount in the provided list of pools in the provided order
+ * This function allocates the requested amount in the provided list of pools in the provided order.
+ * Empty array is returned if not enough capacity is available.
  *
  * @param {BigNumber} coverAmount - The amount to be covered.
  * @param {Array<object>} pools - An array of pool data objects.

--- a/src/lib/quoteEngine.js
+++ b/src/lib/quoteEngine.js
@@ -49,7 +49,7 @@ const calculatePoolAllocations = (coverAmount, pools) => {
     }
   }
 
-  if (coverAmountLeft > 0) {
+  if (coverAmountLeft.gt(0)) {
     // not enough total capacity available
     return [];
   }

--- a/src/lib/quoteEngine.js
+++ b/src/lib/quoteEngine.js
@@ -38,7 +38,7 @@ const calculatePoolAllocations = (coverAmount, pools) => {
     }
 
     const allocation = {
-      pool,
+      poolId: pool.poolId,
       amount: bnMin(pool.availableCapacityInNXM, coverAmountLeft),
     };
 
@@ -138,7 +138,7 @@ const quoteEngine = (store, productId, amount, period, coverAsset) => {
   const allocations = calculatePoolAllocations(amountToAllocate, poolsInPriorityOrder);
 
   const poolsWithPremium = allocations.map(allocation => {
-    const pool = allocation.pool;
+    const pool = poolsData.find(data => allocation.poolId === data.poolId);
     const premiumPerYear = calculatePremiumPerYear(allocation.amount, pool.basePrice);
 
     const premiumInNxm = premiumPerYear.mul(period).div(ONE_YEAR);

--- a/src/routes/quote.js
+++ b/src/routes/quote.js
@@ -206,7 +206,11 @@ router.get(
       capacities: quote.capacities.map(({ poolId, capacity }) => ({
         poolId: poolId.toString(),
         // NOTE: capacity[n].assetId is currently a string (it should ideally a number - BREAKING CHANGE)
-        capacity: capacity.map(({ assetId, amount, asset }) => ({ assetId, amount: amount.toString(), asset })),
+        capacity: capacity.map(({ assetId, amount, asset }) => ({
+          assetId: assetId.toString(),
+          amount: amount.toString(),
+          asset,
+        })),
       })),
     };
 

--- a/test/unit/calculatePoolAllocations.js
+++ b/test/unit/calculatePoolAllocations.js
@@ -104,7 +104,7 @@ describe('calculateOptimalPoolAllocation', function () {
     expect(calculatePoolAllocations(coverAmount, pools)).to.deep.equal(expectedAllocations);
   });
 
-  it('return empty object when there is not enough capacity available to satisfy coverAmount', () => {
+  it('return empty array when there is not enough capacity available to satisfy coverAmount', () => {
     const coverAmount = parseEther('1000');
 
     const pools = formatPools([

--- a/test/unit/calculatePoolAllocations.js
+++ b/test/unit/calculatePoolAllocations.js
@@ -33,7 +33,7 @@ describe('calculateOptimalPoolAllocation', function () {
       { price: '400', capacity: '1000' },
     ]);
 
-    const expectedAllocations = [{ pool: pools[0], amount: coverAmount }];
+    const expectedAllocations = [{ poolId: pools[0].poolId, amount: coverAmount }];
 
     expect(calculatePoolAllocations(coverAmount, pools)).to.deep.equal(expectedAllocations);
   });
@@ -47,8 +47,8 @@ describe('calculateOptimalPoolAllocation', function () {
     ]);
 
     const expectedAllocations = [
-      { pool: pools[0], amount: parseEther('10') },
-      { pool: pools[1], amount: parseEther('5') },
+      { poolId: pools[0].poolId, amount: parseEther('10') },
+      { poolId: pools[1].poolId, amount: parseEther('5') },
     ];
 
     expect(calculatePoolAllocations(coverAmount, pools)).to.deep.equal(expectedAllocations);
@@ -62,7 +62,7 @@ describe('calculateOptimalPoolAllocation', function () {
       { price: '210', capacity: '100' },
     ]);
 
-    const expectedAllocations = [{ pool: pools[1], amount: parseEther('30') }];
+    const expectedAllocations = [{ poolId: pools[1].poolId, amount: parseEther('30') }];
 
     expect(calculatePoolAllocations(coverAmount, pools)).to.deep.equal(expectedAllocations);
   });
@@ -77,9 +77,9 @@ describe('calculateOptimalPoolAllocation', function () {
     ]);
 
     const expectedAllocations = [
-      { pool: pools[0], amount: parseEther('300000') },
-      { pool: pools[1], amount: parseEther('500000') },
-      { pool: pools[2], amount: parseEther('200000') },
+      { poolId: pools[0].poolId, amount: parseEther('300000') },
+      { poolId: pools[1].poolId, amount: parseEther('500000') },
+      { poolId: pools[2].poolId, amount: parseEther('200000') },
     ];
 
     expect(calculatePoolAllocations(coverAmount, pools)).to.deep.equal(expectedAllocations);
@@ -96,9 +96,9 @@ describe('calculateOptimalPoolAllocation', function () {
     ]);
 
     const expectedAllocations = [
-      { pool: pools[0], amount: parseEther('15') },
-      { pool: pools[1], amount: parseEther('10') },
-      { pool: pools[3], amount: parseEther('5') },
+      { poolId: pools[0].poolId, amount: parseEther('15') },
+      { poolId: pools[1].poolId, amount: parseEther('10') },
+      { poolId: pools[3].poolId, amount: parseEther('5') },
     ];
 
     expect(calculatePoolAllocations(coverAmount, pools)).to.deep.equal(expectedAllocations);

--- a/test/unit/calculatePoolAllocations.js
+++ b/test/unit/calculatePoolAllocations.js
@@ -7,12 +7,17 @@ const sinon = require('sinon');
 
 const { calculatePoolAllocations } = require('../../src/lib/quoteEngine');
 
-const INITIAL_POOL_INDEX = 1;
+const formatPools = pools => {
+  return pools.map((pool, id) => {
+    return {
+      poolId: id + 1,
+      basePrice: BigNumber.from(pool.price),
+      availableCapacityInNXM: parseEther(pool.capacity),
+    };
+  });
+};
 
-const sortByBasePrice = (a, b) => a.basePrice - b.basePrice;
-
-// TODO: rewrite all tests
-describe.skip('calculateOptimalPoolAllocation', function () {
+describe('calculateOptimalPoolAllocation', function () {
   this.timeout(0);
 
   afterEach(function () {
@@ -20,362 +25,95 @@ describe.skip('calculateOptimalPoolAllocation', function () {
   });
 
   it('returns optimal pool allocation for 3 pools with all allocation in 1 pool', () => {
-    const pool1 = {
-      basePrice: BigNumber.from('300'),
-      initialCapacityUsed: parseEther('1000'),
-      totalCapacity: parseEther('10000'),
-    };
+    const coverAmount = parseEther('500');
 
-    const pool2 = {
-      basePrice: BigNumber.from('200'),
-      initialCapacityUsed: parseEther('1000'),
-      totalCapacity: parseEther('10000'),
-    };
+    const pools = formatPools([
+      { price: '200', capacity: '1000' },
+      { price: '300', capacity: '1000' },
+      { price: '400', capacity: '1000' },
+    ]);
 
-    const pool3 = {
-      basePrice: BigNumber.from('400'),
-      initialCapacityUsed: parseEther('1000'),
-      totalCapacity: parseEther('10000'),
-    };
+    const expectedAllocations = [{ pool: pools[0], amount: coverAmount }];
 
-    let i = 0;
-    let pools = [pool1, pool2, pool3];
-    pools.forEach(pool => {
-      pool.poolId = i++;
-    });
-
-    pools = pools.sort(sortByBasePrice);
-
-    const amount = parseEther('1000');
-    const optimalAllocations = calculatePoolAllocations(amount, pools);
-
-    expect(optimalAllocations[pool2.poolId].toString()).to.be.equal(amount.toString());
+    expect(calculatePoolAllocations(coverAmount, pools)).to.deep.equal(expectedAllocations);
   });
 
   it('returns optimal pool allocation for 2 pools', () => {
-    const pool1 = {
-      basePrice: BigNumber.from('201'),
-      initialCapacityUsed: parseEther('9990'),
-      totalCapacity: parseEther('10000'),
-    };
+    const coverAmount = parseEther('15');
 
-    const pool2 = {
-      basePrice: BigNumber.from('200'),
-      initialCapacityUsed: parseEther('9990'),
-      totalCapacity: parseEther('10000'),
-    };
+    const pools = formatPools([
+      { price: '200', capacity: '10' },
+      { price: '201', capacity: '10' },
+    ]);
 
-    let i = INITIAL_POOL_INDEX;
-    let pools = [pool1, pool2];
-    pools.forEach(pool => {
-      pool.poolId = i++;
-    });
+    const expectedAllocations = [
+      { pool: pools[0], amount: parseEther('10') },
+      { pool: pools[1], amount: parseEther('5') },
+    ];
 
-    pools = pools.sort(sortByBasePrice);
-
-    const amount = parseEther('15');
-    const optimalAllocations = calculatePoolAllocations(amount, pools);
-
-    expect(optimalAllocations[pool1.poolId].toString()).to.be.equal(parseEther('5.1').toString());
-    expect(optimalAllocations[pool2.poolId].toString()).to.be.equal(parseEther('9.9').toString());
+    expect(calculatePoolAllocations(coverAmount, pools)).to.deep.equal(expectedAllocations);
   });
 
   it('returns optimal pool allocation for 2 pools where 1 is cheaper but already at full capacity', () => {
-    const pool1 = {
-      basePrice: BigNumber.from('200'),
-      initialCapacityUsed: parseEther('10000'),
-      totalCapacity: parseEther('10000'),
-    };
+    const coverAmount = parseEther('30');
 
-    const pool2 = {
-      basePrice: BigNumber.from('210'),
-      initialCapacityUsed: parseEther('8990'),
-      totalCapacity: parseEther('10000'),
-    };
-    let i = 0;
-    let pools = [pool1, pool2];
-    pools.forEach(pool => {
-      pool.poolId = i++;
-    });
+    const pools = formatPools([
+      { price: '200', capacity: '0' },
+      { price: '210', capacity: '100' },
+    ]);
 
-    pools = pools.sort(sortByBasePrice);
+    const expectedAllocations = [{ pool: pools[1], amount: parseEther('30') }];
 
-    const amount = parseEther('30');
-    const optimalAllocations = calculatePoolAllocations(amount, pools);
-
-    expect(optimalAllocations[pool1.poolId]).to.be.equal(undefined);
-    expect(optimalAllocations[pool2.poolId].toString()).to.be.equal(parseEther('30').toString());
-  });
-  it('returns optimal pool allocation for 2 pools where both have no capacity used', () => {
-    const pool1 = {
-      basePrice: BigNumber.from('200'),
-      initialCapacityUsed: parseEther('0'),
-      totalCapacity: parseEther('10000'),
-    };
-
-    const pool2 = {
-      basePrice: BigNumber.from('200'),
-      initialCapacityUsed: parseEther('0'),
-      totalCapacity: parseEther('10000'),
-    };
-    let i = INITIAL_POOL_INDEX;
-    let pools = [pool1, pool2];
-    pools.forEach(pool => {
-      pool.poolId = i++;
-    });
-
-    pools = pools.sort(sortByBasePrice);
-
-    const amount = parseEther('50');
-    const optimalAllocations = calculatePoolAllocations(amount, pools);
-
-    expect(optimalAllocations[pool1.poolId].toString()).to.be.equal(parseEther('50').toString());
-    expect(optimalAllocations[pool2.poolId]).to.be.equal(undefined);
-  });
-
-  it('returns optimal pool allocation for 2 pools where one has 0 capacity', () => {
-    const pool1 = {
-      basePrice: BigNumber.from('210'),
-      initialCapacityUsed: parseEther('7000'),
-      totalCapacity: parseEther('10000'),
-    };
-
-    const pool2 = {
-      basePrice: BigNumber.from('200'),
-      initialCapacityUsed: parseEther('0'),
-      totalCapacity: parseEther('0'),
-    };
-    let i = INITIAL_POOL_INDEX;
-    let pools = [pool1, pool2];
-    pools.forEach(pool => {
-      pool.poolId = i++;
-    });
-
-    pools = pools.sort(sortByBasePrice);
-
-    const amount = parseEther('50');
-    const optimalAllocations = calculatePoolAllocations(amount, pools);
-
-    expect(optimalAllocations[pool1.poolId].toString()).to.be.equal(parseEther('50').toString());
-    expect(optimalAllocations[pool2.poolId]).to.be.equal(undefined);
+    expect(calculatePoolAllocations(coverAmount, pools)).to.deep.equal(expectedAllocations);
   });
 
   it('returns optimal pool allocation for 1 million ETH across 3 pools', () => {
-    const pool1 = {
-      basePrice: BigNumber.from('210'),
-      initialCapacityUsed: parseEther('9400000'),
-      totalCapacity: parseEther('10000000'),
-    };
+    const coverAmount = parseEther('1000000');
 
-    const pool2 = {
-      basePrice: BigNumber.from('200'),
-      initialCapacityUsed: parseEther('9700000'),
-      totalCapacity: parseEther('10000000'),
-    };
+    const pools = formatPools([
+      { price: '200', capacity: '300000' },
+      { price: '210', capacity: '500000' },
+      { price: '214', capacity: '700000' },
+    ]);
 
-    const pool3 = {
-      basePrice: BigNumber.from('214'),
-      initialCapacityUsed: parseEther('9700000'),
-      totalCapacity: parseEther('10000000'),
-    };
-    let i = INITIAL_POOL_INDEX;
-    let pools = [pool1, pool2, pool3];
-    pools.forEach(pool => {
-      pool.poolId = i++;
-    });
+    const expectedAllocations = [
+      { pool: pools[0], amount: parseEther('300000') },
+      { pool: pools[1], amount: parseEther('500000') },
+      { pool: pools[2], amount: parseEther('200000') },
+    ];
 
-    pools = pools.sort(sortByBasePrice);
-
-    const amount = parseEther('1000000');
-    const optimalAllocations = calculatePoolAllocations(amount, pools);
-
-    expect(optimalAllocations[pool1.poolId].toString()).to.be.equal(parseEther('599400').toString());
-    expect(optimalAllocations[pool2.poolId].toString()).to.be.equal(parseEther('299700').toString());
-    expect(optimalAllocations[pool3.poolId].toString()).to.be.equal(parseEther('100900').toString());
+    expect(calculatePoolAllocations(coverAmount, pools)).to.deep.equal(expectedAllocations);
   });
 
-  it('returns optimal pool allocation for 2 same fixed price pools with all allocated to the first', () => {
-    const pool1 = {
-      basePrice: BigNumber.from('200'),
-      initialCapacityUsed: parseEther('9910'),
-      totalCapacity: parseEther('10000'),
-    };
+  it('keeps the priority order when pools are not sorted by price', () => {
+    const coverAmount = parseEther('30');
 
-    const pool2 = {
-      basePrice: BigNumber.from('200'),
-      initialCapacityUsed: parseEther('9990'),
-      totalCapacity: parseEther('10000'),
-    };
+    const pools = formatPools([
+      { price: '300', capacity: '15' },
+      { price: '200', capacity: '10' },
+      { price: '200', capacity: '0' },
+      { price: '205', capacity: '20' },
+    ]);
 
-    let i = INITIAL_POOL_INDEX;
-    let pools = [pool1, pool2];
-    pools.forEach(pool => {
-      pool.poolId = i++;
-    });
+    const expectedAllocations = [
+      { pool: pools[0], amount: parseEther('15') },
+      { pool: pools[1], amount: parseEther('10') },
+      { pool: pools[3], amount: parseEther('5') },
+    ];
 
-    pools = pools.sort(sortByBasePrice);
-
-    const amount = parseEther('60');
-    const optimalAllocations = calculatePoolAllocations(amount, pools);
-
-    expect(optimalAllocations[pool1.poolId].toString()).to.be.equal(parseEther('60').toString());
-    expect(optimalAllocations[pool2.poolId]).to.be.equal(undefined);
+    expect(calculatePoolAllocations(coverAmount, pools)).to.deep.equal(expectedAllocations);
   });
 
-  it('returns optimal pool allocation for 2 pools with fixed pricing where it all goes to the cheapest pool', () => {
-    const pool1 = {
-      basePrice: BigNumber.from('210'),
-      initialCapacityUsed: parseEther('9910'),
-      totalCapacity: parseEther('10000'),
-    };
-    const pool2 = {
-      basePrice: BigNumber.from('200'),
-      initialCapacityUsed: parseEther('8000'),
-      totalCapacity: parseEther('10000'),
-    };
+  it('return empty object when there is not enough capacity available to satisfy coverAmount', () => {
+    const coverAmount = parseEther('1000');
 
-    let i = 0;
-    let pools = [pool1, pool2];
-    pools.forEach(pool => {
-      pool.poolId = i++;
-    });
+    const pools = formatPools([
+      { price: '200', capacity: '500' },
+      { price: '210', capacity: '499' },
+    ]);
 
-    pools = pools.sort(sortByBasePrice);
+    const expectedAllocations = [];
 
-    const amount = parseEther('60');
-    const optimalAllocations = calculatePoolAllocations(amount, pools);
-
-    expect(optimalAllocations[pool1.poolId]).to.be.equal(undefined);
-    expect(optimalAllocations[pool2.poolId].toString()).to.be.equal(parseEther('60').toString());
-  });
-
-  it('returns optimal pool allocation for 3 pools with fixed pricing where allocation goes to each pool', () => {
-    const pool1 = {
-      basePrice: BigNumber.from('200'),
-      initialCapacityUsed: parseEther('9940'),
-      totalCapacity: parseEther('10000'),
-    };
-
-    const pool2 = {
-      basePrice: BigNumber.from('200'),
-      initialCapacityUsed: parseEther('9980'),
-      totalCapacity: parseEther('10000'),
-    };
-
-    const pool3 = {
-      basePrice: BigNumber.from('200'),
-      initialCapacityUsed: parseEther('9970'),
-      totalCapacity: parseEther('10000'),
-    };
-
-    let i = INITIAL_POOL_INDEX;
-    let pools = [pool1, pool2, pool3];
-    pools.forEach(pool => {
-      pool.poolId = i++;
-    });
-
-    pools = pools.sort(sortByBasePrice);
-
-    const amount = parseEther('100');
-    const optimalAllocations = calculatePoolAllocations(amount, pools);
-
-    expect(optimalAllocations[pool1.poolId].toString()).to.be.equal(parseEther('59.9').toString());
-    expect(optimalAllocations[pool2.poolId].toString()).to.be.equal(parseEther('19.9').toString());
-    expect(optimalAllocations[pool3.poolId].toString()).to.be.equal(parseEther('20.2').toString());
-  });
-
-  it('returns optimal pool allocation when 1 pool is filled to capacity and partially fills the second', () => {
-    const pool1 = {
-      basePrice: BigNumber.from('200'),
-      initialCapacityUsed: parseEther('9200'),
-      totalCapacity: parseEther('10000'),
-    };
-
-    const pool2 = {
-      basePrice: BigNumber.from('3000'),
-      initialCapacityUsed: parseEther('7000'),
-      totalCapacity: parseEther('10000'),
-    };
-
-    let i = INITIAL_POOL_INDEX;
-    let pools = [pool1, pool2];
-    pools.forEach(pool => {
-      pool.poolId = i++;
-    });
-
-    pools = pools.sort(sortByBasePrice);
-
-    const amount = parseEther('1000');
-    const optimalAllocations = calculatePoolAllocations(amount, pools);
-
-    // resulting UNIT_SIZE is 3 ETH because of the size of the amount
-    // therefore the first pool is only partially filled
-    expect(optimalAllocations[pool1.poolId].toString()).to.be.equal(parseEther('799.2').toString());
-    expect(optimalAllocations[pool2.poolId].toString()).to.be.equal(parseEther('200.8').toString());
-  });
-
-  it('return empty object when there is not enough capacity available to satisfy coverAmount', async function () {
-    const pool1 = {
-      basePrice: BigNumber.from('200'),
-      initialCapacityUsed: parseEther('9500'),
-      totalCapacity: parseEther('10000'),
-    };
-
-    const pool2 = {
-      basePrice: BigNumber.from('200'),
-      initialCapacityUsed: parseEther('9600'),
-      totalCapacity: parseEther('10000'),
-    };
-
-    let i = INITIAL_POOL_INDEX;
-    let pools = [pool1, pool2];
-    pools.forEach(pool => {
-      pool.poolId = i++;
-    });
-
-    pools = pools.sort(sortByBasePrice);
-
-    const amount = parseEther('1000');
-    const allocations = calculatePoolAllocations(amount, pools);
-    expect(allocations).to.deep.equal({});
-  });
-
-  it('computes optimal pool allocation across 4 pools', () => {
-    const pool1 = {
-      basePrice: BigNumber.from('300'),
-      initialCapacityUsed: BigNumber.from('0'),
-      totalCapacity: BigNumber.from('7228110000000000000000'),
-    };
-    const pool2 = {
-      basePrice: BigNumber.from('600'),
-      initialCapacityUsed: BigNumber.from('0'),
-      totalCapacity: BigNumber.from('8390570000000000000000'),
-    };
-    const pool3 = {
-      basePrice: BigNumber.from('103'),
-      initialCapacityUsed: BigNumber.from('2741190000000000000000'),
-      totalCapacity: BigNumber.from('68382300000000000000000'),
-    };
-    const pool4 = {
-      basePrice: BigNumber.from('103'),
-      initialCapacityUsed: BigNumber.from('353900000000000000000'),
-      totalCapacity: BigNumber.from('23242550000000000000000'),
-    };
-
-    let i = INITIAL_POOL_INDEX;
-    let pools = [pool1, pool2, pool3, pool4];
-    pools.forEach(pool => {
-      pool.poolId = i++;
-    });
-
-    pools = pools.sort(sortByBasePrice);
-
-    const amount = BigNumber.from('88600380000000000000000');
-    const optimalAllocations = calculatePoolAllocations(amount, pools);
-
-    expect(optimalAllocations[pool1.poolId].toString()).to.be.equal('159149760000000000000');
-    expect(optimalAllocations[pool2.poolId]).to.be.equal(undefined);
-    expect(optimalAllocations[pool3.poolId].toString()).to.be.equal('65575468890000000000000');
-    expect(optimalAllocations[pool4.poolId].toString()).to.be.equal('22865761350000000000000');
+    expect(calculatePoolAllocations(coverAmount, pools)).to.deep.equal(expectedAllocations);
   });
 });

--- a/test/unit/calculatePoolAllocations.js
+++ b/test/unit/calculatePoolAllocations.js
@@ -11,7 +11,8 @@ const INITIAL_POOL_INDEX = 1;
 
 const sortByBasePrice = (a, b) => a.basePrice - b.basePrice;
 
-describe('calculateOptimalPoolAllocation', function () {
+// TODO: rewrite all tests
+describe.skip('calculateOptimalPoolAllocation', function () {
   this.timeout(0);
 
   afterEach(function () {

--- a/test/unit/pricingEngine.js
+++ b/test/unit/pricingEngine.js
@@ -135,25 +135,21 @@ describe('pricingEngine', () => {
         '1_1': {
           ...mockStore.poolProducts['1_1'],
           targetPrice: BigNumber.from(100),
-          allocations: Array(8).fill(BigNumber.from(0)),
-          trancheCapacities: [
-            ...Array(7).fill(BigNumber.from(0)),
-            BigNumber.from(75), // 60 available + 15 allocated
-          ],
+          // 60k available + 15k allocated
+          allocations: [...Array(7).fill(BigNumber.from(0)), BigNumber.from(15000)],
+          trancheCapacities: [...Array(7).fill(BigNumber.from(0)), BigNumber.from(75000)],
         },
         '1_2': {
           ...mockStore.poolProducts['1_2'],
           targetPrice: BigNumber.from(200),
-          allocations: Array(8).fill(BigNumber.from(0)),
-          trancheCapacities: [
-            ...Array(7).fill(BigNumber.from(0)),
-            BigNumber.from(25), // 20 available + 5 allocated
-          ],
+          // 20k available + 5k allocated
+          allocations: [...Array(7).fill(BigNumber.from(0)), BigNumber.from(5000)],
+          trancheCapacities: [...Array(7).fill(BigNumber.from(0)), BigNumber.from(25000)],
         },
       });
 
       const result = pricingEngine(store, 1);
-      // Weighted average: ((100 * 60) + (200 * 20)) / (60 + 20) = 125
+      // Weighted average: ((100 * 60k) + (200 * 20k)) / (60k + 20k) = 125
       expect(result.weightedAveragePrice.toString()).to.equal('125');
       expect(result.pricePerPool).to.have.length(2);
     });

--- a/test/unit/quoteEngine.js
+++ b/test/unit/quoteEngine.js
@@ -98,23 +98,23 @@ describe('Quote Engine tests', () => {
 
     const [quote1, quote2, quote3] = quoteEngine(store, productId, amount, MIN_COVER_PERIOD, 1);
 
-    expect(quote1.poolId).to.be.equal(1); // partially filled
-    expect(quote1.premiumInNxm.toString()).to.be.equal('51949989041095890');
-    expect(quote1.premiumInAsset.toString()).to.be.equal('1492234291979572267');
-    expect(quote1.coverAmountInNxm.toString()).to.be.equal('31602910000000000000');
-    expect(quote1.coverAmountInAsset.toString()).to.be.equal('907775860954239803444');
+    expect(quote1.poolId).to.be.equal(18); // capacity filled
+    expect(quote1.premiumInNxm.toString()).to.be.equal('2740621019178082191');
+    expect(quote1.premiumInAsset.toString()).to.be.equal('78722801325373825281');
+    expect(quote1.coverAmountInNxm.toString()).to.be.equal('1667211120000000000000');
+    expect(quote1.coverAmountInAsset.toString()).to.be.equal('47889704139602410393499');
 
-    expect(quote2.poolId).to.be.equal(18); // capacity filled
-    expect(quote2.premiumInNxm.toString()).to.be.equal('2740621019178082191');
-    expect(quote2.premiumInAsset.toString()).to.be.equal('78722801325373825281');
-    expect(quote2.coverAmountInNxm.toString()).to.be.equal('1667211120000000000000');
-    expect(quote2.coverAmountInAsset.toString()).to.be.equal('47889704139602410393499');
+    expect(quote2.poolId).to.be.equal(22); // capacity filled
+    expect(quote2.premiumInNxm.toString()).to.be.equal('3044672827397260273');
+    expect(quote2.premiumInAsset.toString()).to.be.equal('87456518947607277504');
+    expect(quote2.coverAmountInNxm.toString()).to.be.equal('1852175970000000000000');
+    expect(quote2.coverAmountInAsset.toString()).to.be.equal('53202715693127760499173');
 
-    expect(quote3.poolId).to.be.equal(22); // capacity filled
-    expect(quote3.premiumInNxm.toString()).to.be.equal('3044672827397260273');
-    expect(quote3.premiumInAsset.toString()).to.be.equal('87456518947607277504');
-    expect(quote3.coverAmountInNxm.toString()).to.be.equal('1852175970000000000000');
-    expect(quote3.coverAmountInAsset.toString()).to.be.equal('53202715693127760499173');
+    expect(quote3.poolId).to.be.equal(1); // partially filled
+    expect(quote3.premiumInNxm.toString()).to.be.equal('51949989041095890');
+    expect(quote3.premiumInAsset.toString()).to.be.equal('1492234291979572267');
+    expect(quote3.coverAmountInNxm.toString()).to.be.equal('31602910000000000000');
+    expect(quote3.coverAmountInAsset.toString()).to.be.equal('907775860954239803444');
   });
 
   it('should return empty array for cover over the capacity', () => {

--- a/test/unit/responses.js
+++ b/test/unit/responses.js
@@ -17,27 +17,27 @@ const capacities = [
     availableCapacity: [
       {
         assetId: 0,
-        amount: '4761714669056628480',
+        amount: '4756936506323084609',
         asset: assets[0],
       },
       {
         assetId: 1,
-        amount: '13305160151201388636532',
+        amount: '13291809031947765136018',
         asset: assets[1],
       },
       {
         assetId: 6,
-        amount: '13305160144',
+        amount: '13291809025',
         asset: assets[6],
       },
       {
         assetId: 7,
-        amount: '38109316',
+        amount: '38071075',
         asset: assets[7],
       },
       {
         assetId: 255,
-        amount: '463200000000000000000',
+        amount: '462735200000000000000',
         asset: assets[255],
       },
     ],
@@ -50,27 +50,27 @@ const capacities = [
     availableCapacity: [
       {
         assetId: 0,
-        amount: '5267492652039327360',
+        amount: '5262225159387288032',
         asset: assets[0],
       },
       {
         assetId: 1,
-        amount: '14718402550681328880309',
+        amount: '14703684148130647551429',
         asset: assets[1],
       },
       {
         assetId: 6,
-        amount: '14718402543',
+        amount: '14703684141',
         asset: assets[6],
       },
       {
         assetId: 7,
-        amount: '42157197',
+        amount: '42115040',
         asset: assets[7],
       },
       {
         assetId: 255,
-        amount: '512400000000000000000',
+        amount: '511887600000000000000',
         asset: assets[255],
       },
     ],
@@ -83,27 +83,27 @@ const capacities = [
     availableCapacity: [
       {
         assetId: 0,
-        amount: '4761714669056628480',
+        amount: '4756936506323084609',
         asset: assets[0],
       },
       {
         assetId: 1,
-        amount: '13305160151201388636532',
+        amount: '13291809031947765136018',
         asset: assets[1],
       },
       {
         assetId: 6,
-        amount: '13305160144',
+        amount: '13291809025',
         asset: assets[6],
       },
       {
         assetId: 7,
-        amount: '38109316',
+        amount: '38071075',
         asset: assets[7],
       },
       {
         assetId: 255,
-        amount: '463200000000000000000',
+        amount: '462735200000000000000',
         asset: assets[255],
       },
     ],
@@ -113,27 +113,27 @@ const capacities = [
     availableCapacity: [
       {
         assetId: 0,
-        amount: '650955796175312058720',
+        amount: '650304840379136746661',
         asset: assets[0],
       },
       {
         assetId: 1,
-        amount: '1818897544564809351595684',
+        amount: '1817078647020244542244088',
         asset: assets[1],
       },
       {
         assetId: 6,
-        amount: '1818897543689',
+        amount: '1817078646146',
         asset: assets[6],
       },
       {
         assetId: 7,
-        amount: '5209778910',
+        amount: '5204569131',
         asset: assets[7],
       },
       {
         assetId: 255,
-        amount: '63322300000000000000000',
+        amount: '63258977700000000000000',
         asset: assets[255],
       },
     ],
@@ -146,27 +146,27 @@ const capacities = [
     availableCapacity: [
       {
         assetId: 0,
-        amount: '37227212755184497584',
+        amount: '37189969094364825844',
         asset: assets[0],
       },
       {
         assetId: 1,
-        amount: '104020098245136227727466',
+        amount: '103916032187788669387861',
         asset: assets[1],
       },
       {
         assetId: 6,
-        amount: '104020098195',
+        amount: '103916032137',
         asset: assets[6],
       },
       {
         assetId: 7,
-        amount: '297939658',
+        amount: '297641587',
         asset: assets[7],
       },
       {
         assetId: 255,
-        amount: '3621310000000000000000',
+        amount: '3617687090000000000000',
         asset: assets[255],
       },
     ],
@@ -183,7 +183,7 @@ const productCapacityPerPools = {
       allocatedNxm: '0',
       availableCapacity: [
         {
-          amount: '1011555965965397760',
+          amount: '1010527961934945120',
           asset: {
             decimals: 18,
             id: 0,
@@ -192,7 +192,7 @@ const productCapacityPerPools = {
           assetId: 0,
         },
         {
-          amount: '2826484798959880487553',
+          amount: '2823612355058498495188',
           asset: {
             decimals: 18,
             id: 1,
@@ -201,7 +201,7 @@ const productCapacityPerPools = {
           assetId: 1,
         },
         {
-          amount: '2826484797',
+          amount: '2823612353',
           asset: {
             decimals: 6,
             id: 6,
@@ -210,7 +210,7 @@ const productCapacityPerPools = {
           assetId: 6,
         },
         {
-          amount: '8095761',
+          amount: '8087534',
           asset: {
             decimals: 8,
             id: 7,
@@ -219,7 +219,7 @@ const productCapacityPerPools = {
           assetId: 7,
         },
         {
-          amount: '98400000000000000000',
+          amount: '98300000000000000000',
           asset: {
             decimals: 18,
             id: 255,
@@ -236,7 +236,7 @@ const productCapacityPerPools = {
       allocatedNxm: '0',
       availableCapacity: [
         {
-          amount: '3750158703091230720',
+          amount: '3746408544388139489',
           asset: {
             decimals: 18,
             id: 0,
@@ -245,7 +245,7 @@ const productCapacityPerPools = {
           assetId: 0,
         },
         {
-          amount: '10478675352241508148979',
+          amount: '10468196676889266640830',
           asset: {
             decimals: 18,
             id: 1,
@@ -254,7 +254,7 @@ const productCapacityPerPools = {
           assetId: 1,
         },
         {
-          amount: '10478675347',
+          amount: '10468196671',
           asset: {
             decimals: 6,
             id: 6,
@@ -263,7 +263,7 @@ const productCapacityPerPools = {
           assetId: 6,
         },
         {
-          amount: '30013555',
+          amount: '29983541',
           asset: {
             decimals: 8,
             id: 7,
@@ -272,7 +272,7 @@ const productCapacityPerPools = {
           assetId: 7,
         },
         {
-          amount: '364800000000000000000',
+          amount: '364435200000000000000',
           asset: {
             decimals: 18,
             id: 255,
@@ -307,27 +307,27 @@ const poolProductCapacities = {
         availableCapacity: [
           {
             assetId: 0,
-            amount: '3750158703091230720',
+            amount: '3746408544388139489',
             asset: { id: 0, symbol: 'ETH', decimals: 18 },
           },
           {
             assetId: 1,
-            amount: '10478675352241508148979',
+            amount: '10468196676889266640830',
             asset: { id: 1, symbol: 'DAI', decimals: 18 },
           },
           {
             assetId: 6,
-            amount: '10478675347',
+            amount: '10468196671',
             asset: { id: 6, symbol: 'USDC', decimals: 6 },
           },
           {
             assetId: 7,
-            amount: '30013555',
+            amount: '29983541',
             asset: { id: 7, symbol: 'cbBTC', decimals: 8 },
           },
           {
             assetId: 255,
-            amount: '364800000000000000000',
+            amount: '364435200000000000000',
             asset: { id: 255, symbol: 'NXM', decimals: 18 },
           },
         ],
@@ -340,27 +340,27 @@ const poolProductCapacities = {
         availableCapacity: [
           {
             assetId: 0,
-            amount: '3750158703091230720',
+            amount: '3746408544388139489',
             asset: { id: 0, symbol: 'ETH', decimals: 18 },
           },
           {
             assetId: 1,
-            amount: '10478675352241508148979',
+            amount: '10468196676889266640830',
             asset: { id: 1, symbol: 'DAI', decimals: 18 },
           },
           {
             assetId: 6,
-            amount: '10478675347',
+            amount: '10468196671',
             asset: { id: 6, symbol: 'USDC', decimals: 6 },
           },
           {
             assetId: 7,
-            amount: '30013555',
+            amount: '29983541',
             asset: { id: 7, symbol: 'cbBTC', decimals: 8 },
           },
           {
             assetId: 255,
-            amount: '364800000000000000000',
+            amount: '364435200000000000000',
             asset: { id: 255, symbol: 'NXM', decimals: 18 },
           },
         ],
@@ -373,27 +373,27 @@ const poolProductCapacities = {
         availableCapacity: [
           {
             assetId: 0,
-            amount: '3750158703091230720',
+            amount: '3746408544388139489',
             asset: { id: 0, symbol: 'ETH', decimals: 18 },
           },
           {
             assetId: 1,
-            amount: '10478675352241508148979',
+            amount: '10468196676889266640830',
             asset: { id: 1, symbol: 'DAI', decimals: 18 },
           },
           {
             assetId: 6,
-            amount: '10478675347',
+            amount: '10468196671',
             asset: { id: 6, symbol: 'USDC', decimals: 6 },
           },
           {
             assetId: 7,
-            amount: '30013555',
+            amount: '29983541',
             asset: { id: 7, symbol: 'cbBTC', decimals: 8 },
           },
           {
             assetId: 255,
-            amount: '364800000000000000000',
+            amount: '364435200000000000000',
             asset: { id: 255, symbol: 'NXM', decimals: 18 },
           },
         ],
@@ -464,27 +464,27 @@ const getQuote = assetId => ({
       capacity: [
         {
           assetId: '0',
-          amount: '1011555965965397760',
+          amount: '1010527961934945120',
           asset: assets[0],
         },
         {
           assetId: '1',
-          amount: '2826484798959880487553',
+          amount: '2823612355058498495188',
           asset: assets[1],
         },
         {
           assetId: '6',
-          amount: '2826484797',
+          amount: '2823612353',
           asset: assets[6],
         },
         {
           assetId: '7',
-          amount: '8095761',
+          amount: '8087534',
           asset: assets[7],
         },
         {
           assetId: '255',
-          amount: '98400000000000000000',
+          amount: '98300000000000000000',
           asset: assets[255],
         },
       ],

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -3,14 +3,14 @@ const { BigNumber, ethers } = require('ethers');
 
 const { Zero } = ethers.constants;
 const { NXM_PER_ALLOCATION_UNIT } = require('../../src/lib/constants');
-const { calculateFirstUsableTrancheIndex, calculateAvailableCapacity } = require('../../src/lib/helpers');
+const { calculateFirstUsableTrancheIndex, calculateAvailableCapacityInNXM } = require('../../src/lib/helpers');
 
 const getCurrentTimestamp = () => BigNumber.from(Math.floor(Date.now() / 1000));
 
 const verifyCapacityCalculation = (response, poolProduct, storeProduct, now, period) => {
   const firstUsableTrancheIndex = calculateFirstUsableTrancheIndex(now, storeProduct.gracePeriod, period);
 
-  const availableCapacity = calculateAvailableCapacity(
+  const availableCapacity = calculateAvailableCapacityInNXM(
     poolProduct.trancheCapacities,
     poolProduct.allocations,
     firstUsableTrancheIndex,
@@ -26,19 +26,19 @@ const verifyUsedCapacity = (response, poolProduct) => {
   poolProduct.allocations.forEach(allocation => {
     totalUsedCapacity = totalUsedCapacity.add(allocation);
   });
-  expect(response.usedCapacity.toString()).to.equal(totalUsedCapacity.mul(NXM_PER_ALLOCATION_UNIT).toString());
+  expect(response.usedCapacity.toString()).to.equal(totalUsedCapacity.toString());
   return totalUsedCapacity;
 };
 
 const calculateExpectedAvailableNXM = (poolIds, productId, poolProducts, firstUsableTrancheIndex) => {
   return poolIds.reduce((total, poolId) => {
     const poolProduct = poolProducts[`${productId}_${poolId}`];
-    const availableCapacity = calculateAvailableCapacity(
+    const availableCapacity = calculateAvailableCapacityInNXM(
       poolProduct.trancheCapacities,
       poolProduct.allocations,
       firstUsableTrancheIndex,
     );
-    return total.add(availableCapacity.mul(NXM_PER_ALLOCATION_UNIT));
+    return total.add(availableCapacity);
   }, Zero);
 };
 


### PR DESCRIPTION
## Description

Closes #168, Closes #169, Closes #170

- Moving calculation of available capacity to one place (in helpers) to be used by both `capacityEngine` and `quoteEngine`.
- `calculatePoolAllocation` is refactored to return an array instead of object, and `quoteEngine` now returns pools in the same priority order as allocation is taken. 

## Testing

Fixed unit tests, and rewrote calculatePoolAllocation tests.

## Checklist

- [x] Performed a self-review of my own code
- [ ] Made corresponding changes to the documentation
