### PR TITLE
fix: round down buffered capacity in nxm allocation units

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -39,7 +39,7 @@ module.exports = {
   MIN_COVER_PERIOD: 30 * 24 * 3600, // seconds
   MAX_COVER_PERIOD: 365 * 24 * 3600, // seconds
 
-  CAPACITY_BUFFER_MINIMUM: parseEther('0.1'), // = 0.1 nxm = 10 allocation units
+  CAPACITY_BUFFER_MINIMUM: 10, // 10 allocation units = 0.1 nxm
   CAPACITY_BUFFER_RATIO: 10, // 0.1%
   CAPACITY_BUFFER_DENOMINATOR: 100_00,
 

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -99,12 +99,13 @@ const calculateFirstUsableTrancheIndex = (now, gracePeriod, period) => {
 
 /* Capacity Calculations */
 
-const bufferedCapacity = capacityInNxm => {
+const bufferedCapacityInNxm = capacity => {
   const capacityBuffer = bnMax(
-    capacityInNxm.mul(CAPACITY_BUFFER_RATIO).div(CAPACITY_BUFFER_DENOMINATOR),
+    capacity.mul(CAPACITY_BUFFER_RATIO).div(CAPACITY_BUFFER_DENOMINATOR),
     CAPACITY_BUFFER_MINIMUM,
   );
-  return bnMax(capacityInNxm.sub(capacityBuffer), Zero);
+
+  return bnMax(capacity.sub(capacityBuffer).mul(NXM_PER_ALLOCATION_UNIT), Zero);
 };
 
 /**
@@ -136,7 +137,7 @@ function calculateAvailableCapacityInNXM(
     return available.add(allocationToAdd);
   }, Zero);
 
-  return bufferedCapacity(unused.mul(NXM_PER_ALLOCATION_UNIT));
+  return bufferedCapacityInNxm(unused);
 }
 
 function getCapacitiesInAssets(capacityInNXM, assets, assetRates) {
@@ -309,7 +310,7 @@ module.exports = {
   calculateTrancheId,
   calculateBucketId,
   calculateFirstUsableTrancheIndex,
-  bufferedCapacity,
+  bufferedCapacityInNxm,
   calculateAvailableCapacityInNXM,
   getCapacitiesInAssets,
   calculateProductDataForTranche,

--- a/test/unit/capacityEngine.js
+++ b/test/unit/capacityEngine.js
@@ -20,7 +20,7 @@ const {
   calculatePremiumPerYear,
   calculateProductDataForTranche,
   calculateTrancheId,
-  bufferedCapacity,
+  bufferedCapacityInNxm,
 } = require('../../src/lib/helpers');
 const mockStore = require('../mocks/store');
 
@@ -140,7 +140,7 @@ describe('capacityEngine', function () {
       // Calculate expected fixed price
       const used = allocations[lastIndex].mul(NXM_PER_ALLOCATION_UNIT);
       const availableCapacity = trancheCapacities[lastIndex].sub(allocations[lastIndex]);
-      const availableInNXM = bufferedCapacity(availableCapacity.mul(NXM_PER_ALLOCATION_UNIT));
+      const availableInNXM = bufferedCapacityInNxm(availableCapacity);
       const expectedFixedPrice = WeiPerEther.mul(calculatePremiumPerYear(NXM_PER_ALLOCATION_UNIT, targetPrice)).div(
         NXM_PER_ALLOCATION_UNIT,
       );

--- a/test/unit/quoteEngine.js
+++ b/test/unit/quoteEngine.js
@@ -67,10 +67,10 @@ describe('Quote Engine tests', () => {
 
       expect(quote.poolId).to.be.equal(1);
 
-      expect(quote.premiumInNxm.toString()).to.be.equal('242387506849315068');
-      expect(quote.premiumInAsset.toString()).to.be.equal('6962445158205009701');
-      expect(quote.coverAmountInNxm.toString()).to.be.equal('147452400000000000000');
-      expect(quote.coverAmountInAsset.toString()).to.be.equal('4235487471241380910599');
+      expect(quote.premiumInNxm.toString()).to.be.equal('242400000000000000');
+      expect(quote.premiumInAsset.toString()).to.be.equal('6962804016949949493');
+      expect(quote.coverAmountInNxm.toString()).to.be.equal('147460000000000000000');
+      expect(quote.coverAmountInAsset.toString()).to.be.equal('4235705776977885942018');
     }
 
     {
@@ -78,10 +78,10 @@ describe('Quote Engine tests', () => {
 
       expect(quote.poolId).to.be.equal(2);
 
-      expect(quote.premiumInNxm.toString()).to.be.equal('444357698630136986');
-      expect(quote.premiumInAsset.toString()).to.be.equal('12763925614622742886');
-      expect(quote.coverAmountInNxm.toString()).to.be.equal('270317600000000000000');
-      expect(quote.coverAmountInAsset.toString()).to.be.equal('7764721415562168594332');
+      expect(quote.premiumInNxm.toString()).to.be.equal('444345205479452054');
+      expect(quote.premiumInAsset.toString()).to.be.equal('12763566755877803094');
+      expect(quote.coverAmountInNxm.toString()).to.be.equal('270310000000000000000');
+      expect(quote.coverAmountInAsset.toString()).to.be.equal('7764503109825663562912');
     }
   });
 
@@ -109,22 +109,22 @@ describe('Quote Engine tests', () => {
     } = quoteEngine(store, productId, amount, MIN_COVER_PERIOD, 1);
 
     expect(quote1.poolId).to.be.equal(18); // capacity filled
-    expect(quote1.premiumInNxm.toString()).to.be.equal('2740621019178082191');
-    expect(quote1.premiumInAsset.toString()).to.be.equal('78722801325373825281');
-    expect(quote1.coverAmountInNxm.toString()).to.be.equal('1667211120000000000000');
-    expect(quote1.coverAmountInAsset.toString()).to.be.equal('47889704139602410393499');
+    expect(quote1.premiumInNxm.toString()).to.be.equal('2740635616438356164');
+    expect(quote1.premiumInAsset.toString()).to.be.equal('78723220623486333875');
+    expect(quote1.coverAmountInNxm.toString()).to.be.equal('1667220000000000000000');
+    expect(quote1.coverAmountInAsset.toString()).to.be.equal('47889959212620853114421');
 
     expect(quote2.poolId).to.be.equal(22); // capacity filled
-    expect(quote2.premiumInNxm.toString()).to.be.equal('3044672827397260273');
-    expect(quote2.premiumInAsset.toString()).to.be.equal('87456518947607277504');
-    expect(quote2.coverAmountInNxm.toString()).to.be.equal('1852175970000000000000');
-    expect(quote2.coverAmountInAsset.toString()).to.be.equal('53202715693127760499173');
+    expect(quote2.premiumInNxm.toString()).to.be.equal('3044679452054794520');
+    expect(quote2.premiumInAsset.toString()).to.be.equal('87456709237178607425');
+    expect(quote2.coverAmountInNxm.toString()).to.be.equal('1852180000000000000000');
+    expect(quote2.coverAmountInAsset.toString()).to.be.equal('53202831452616986193465');
 
     expect(quote3.poolId).to.be.equal(1); // partially filled
-    expect(quote3.premiumInNxm.toString()).to.be.equal('51949989041095890');
-    expect(quote3.premiumInAsset.toString()).to.be.equal('1492234291979572267');
-    expect(quote3.coverAmountInNxm.toString()).to.be.equal('31602910000000000000');
-    expect(quote3.coverAmountInAsset.toString()).to.be.equal('907775860954239803444');
+    expect(quote3.premiumInNxm.toString()).to.be.equal('51928767123287671');
+    expect(quote3.premiumInAsset.toString()).to.be.equal('1491624704295733782');
+    expect(quote3.coverAmountInNxm.toString()).to.be.equal('31590000000000000000');
+    expect(quote3.coverAmountInAsset.toString()).to.be.equal('907405028446571388229');
   });
 
   it('should return empty array for cover over the capacity', () => {
@@ -156,16 +156,16 @@ describe('Quote Engine tests', () => {
     expect(quote.poolsWithPremium.length).to.equal(2);
 
     expect(quote1.poolId).to.be.equal(18); // capacity filled
-    expect(quote1.premiumInNxm.toString()).to.be.equal('2921262115068493150');
-    expect(quote1.premiumInAsset.toString()).to.be.equal('83911615467667531712');
-    expect(quote1.coverAmountInNxm.toString()).to.be.equal('1777101120000000000000');
-    expect(quote1.coverAmountInAsset.toString()).to.be.equal('51046232742831081803837');
+    expect(quote1.premiumInNxm.toString()).to.be.equal('2921276712328767123');
+    expect(quote1.premiumInAsset.toString()).to.be.equal('83912034765780040306');
+    expect(quote1.coverAmountInNxm.toString()).to.be.equal('1777110000000000000000');
+    expect(quote1.coverAmountInAsset.toString()).to.be.equal('51046487815849524524759');
 
     expect(quote2.poolId).to.be.equal(22); // partially filled
-    expect(quote2.premiumInNxm.toString()).to.be.equal('2915981720547945205');
-    expect(quote2.premiumInAsset.toString()).to.be.equal('83759939097293143370');
-    expect(quote2.coverAmountInNxm.toString()).to.be.equal('1773888880000000000000');
-    expect(quote2.coverAmountInAsset.toString()).to.be.equal('50953962950853328892279');
+    expect(quote2.premiumInNxm.toString()).to.be.equal('2915967123287671232');
+    expect(quote2.premiumInAsset.toString()).to.be.equal('83759519799180634777');
+    expect(quote2.coverAmountInNxm.toString()).to.be.equal('1773880000000000000000');
+    expect(quote2.coverAmountInAsset.toString()).to.be.equal('50953707877834886171357');
   });
 
   // TODO: check out the starting tranche of edited cover mockStore.covers[1].start
@@ -176,7 +176,7 @@ describe('Quote Engine tests', () => {
 
     const now = BigNumber.from(Date.now()).div(1000);
 
-    mockStore.covers[1].start = now.sub(TRANCHE_DURATION + 7 * SECONDS_PER_DAY).toNumber();
+    mockStore.covers[1].start = now.sub(TRANCHE_DURATION + 14 * SECONDS_PER_DAY).toNumber();
 
     const quote = quoteEngine(store, productId, amount, MIN_COVER_PERIOD, 1, 1);
     const [quote1, quote2, quote3] = quote.poolsWithPremium;
@@ -184,22 +184,22 @@ describe('Quote Engine tests', () => {
     expect(quote.poolsWithPremium.length).to.equal(3);
 
     expect(quote1.poolId).to.be.equal(18); // capacity filled
-    expect(quote1.premiumInNxm.toString()).to.be.equal('2757042936986301369');
-    expect(quote1.premiumInAsset.toString()).to.be.equal('79194511701945980409');
-    expect(quote1.coverAmountInNxm.toString()).to.be.equal('1677201120000000000000');
-    expect(quote1.coverAmountInAsset.toString()).to.be.equal('48176661285350471430803');
+    expect(quote1.premiumInNxm.toString()).to.be.equal('2757057534246575342');
+    expect(quote1.premiumInAsset.toString()).to.be.equal('79194931000058489003');
+    expect(quote1.coverAmountInNxm.toString()).to.be.equal('1677210000000000000000');
+    expect(quote1.coverAmountInAsset.toString()).to.be.equal('48176916358368914151725');
 
     expect(quote2.poolId).to.be.equal(22); // capacity filled
-    expect(quote2.premiumInNxm.toString()).to.be.equal('3061094745205479452');
-    expect(quote2.premiumInAsset.toString()).to.be.equal('87928229324179432661');
-    expect(quote2.coverAmountInNxm.toString()).to.be.equal('1862165970000000000000');
-    expect(quote2.coverAmountInAsset.toString()).to.be.equal('53489672838875821536476');
+    expect(quote2.premiumInNxm.toString()).to.be.equal('3061101369863013698');
+    expect(quote2.premiumInAsset.toString()).to.be.equal('87928419613750762553');
+    expect(quote2.coverAmountInNxm.toString()).to.be.equal('1862170000000000000000');
+    expect(quote2.coverAmountInAsset.toString()).to.be.equal('53489788598365047230769');
 
     expect(quote3.poolId).to.be.equal(1); // partially filled
-    expect(quote3.premiumInNxm.toString()).to.be.equal('19106153424657534');
-    expect(quote3.premiumInAsset.toString()).to.be.equal('548813538835262012');
-    expect(quote3.coverAmountInNxm.toString()).to.be.equal('11622910000000000000');
-    expect(quote3.coverAmountInAsset.toString()).to.be.equal('333861569458117728837');
+    expect(quote3.premiumInNxm.toString()).to.be.equal('19084931506849315');
+    expect(quote3.premiumInAsset.toString()).to.be.equal('548203951151423527');
+    expect(quote3.coverAmountInNxm.toString()).to.be.equal('11610000000000000000');
+    expect(quote3.coverAmountInAsset.toString()).to.be.equal('333490736950449313622');
   });
 
   it('should calculate full discount for edited cover that started now', () => {

--- a/test/unit/responses.js
+++ b/test/unit/responses.js
@@ -17,27 +17,27 @@ const capacities = [
     availableCapacity: [
       {
         assetId: 0,
-        amount: '4756936506323084609',
+        amount: '4756985850516546336',
         asset: assets[0],
       },
       {
         assetId: 1,
-        amount: '13291809031947765136018',
+        amount: '13291946909255031471651',
         asset: assets[1],
       },
       {
         assetId: 6,
-        amount: '13291809025',
+        amount: '13291946902',
         asset: assets[6],
       },
       {
         assetId: 7,
-        amount: '38071075',
+        amount: '38071470',
         asset: assets[7],
       },
       {
         assetId: 255,
-        amount: '462735200000000000000',
+        amount: '462740000000000000000',
         asset: assets[255],
       },
     ],
@@ -50,27 +50,27 @@ const capacities = [
     availableCapacity: [
       {
         assetId: 0,
-        amount: '5262225159387288032',
+        amount: '5262352631887064160',
         asset: assets[0],
       },
       {
         assetId: 1,
-        amount: '14703684148130647551429',
+        amount: '14704040331174418918482',
         asset: assets[1],
       },
       {
         assetId: 6,
-        amount: '14703684141',
+        amount: '14704040324',
         asset: assets[6],
       },
       {
         assetId: 7,
-        amount: '42115040',
+        amount: '42116060',
         asset: assets[7],
       },
       {
         assetId: 255,
-        amount: '511887600000000000000',
+        amount: '511900000000000000000',
         asset: assets[255],
       },
     ],
@@ -83,27 +83,27 @@ const capacities = [
     availableCapacity: [
       {
         assetId: 0,
-        amount: '4756936506323084609',
+        amount: '4756985850516546336',
         asset: assets[0],
       },
       {
         assetId: 1,
-        amount: '13291809031947765136018',
+        amount: '13291946909255031471651',
         asset: assets[1],
       },
       {
         assetId: 6,
-        amount: '13291809025',
+        amount: '13291946902',
         asset: assets[6],
       },
       {
         assetId: 7,
-        amount: '38071075',
+        amount: '38071470',
         asset: assets[7],
       },
       {
         assetId: 255,
-        amount: '462735200000000000000',
+        amount: '462740000000000000000',
         asset: assets[255],
       },
     ],
@@ -113,60 +113,60 @@ const capacities = [
     availableCapacity: [
       {
         assetId: 0,
-        amount: '650304840379136746661',
+        amount: '650305069624035537600',
         asset: assets[0],
       },
       {
         assetId: 1,
-        amount: '1817078647020244542244088',
+        amount: '1817079287575234550428386',
         asset: assets[1],
       },
       {
         assetId: 6,
-        amount: '1817078646146',
+        amount: '1817079286701',
         asset: assets[6],
       },
       {
         assetId: 7,
-        amount: '5204569131',
+        amount: '5204570966',
         asset: assets[7],
       },
       {
         assetId: 255,
-        amount: '63258977700000000000000',
+        amount: '63259000000000000000000',
         asset: assets[255],
       },
     ],
     allocatedNxm: '32725200000000000000000',
     minAnnualPrice: '0.0775',
-    maxAnnualPrice: '0.08921973183222972',
+    maxAnnualPrice: '0.089219729208492072',
   },
   {
     productId: 4,
     availableCapacity: [
       {
         assetId: 0,
-        amount: '37189969094364825844',
+        amount: '37190101809685157280',
         asset: assets[0],
       },
       {
         assetId: 1,
-        amount: '103916032187788669387861',
+        amount: '103916403020296337803075',
         asset: assets[1],
       },
       {
         assetId: 6,
-        amount: '103916032137',
+        amount: '103916402970',
         asset: assets[6],
       },
       {
         assetId: 7,
-        amount: '297641587',
+        amount: '297642649',
         asset: assets[7],
       },
       {
         assetId: 255,
-        amount: '3617687090000000000000',
+        amount: '3617700000000000000000',
         asset: assets[255],
       },
     ],
@@ -236,7 +236,7 @@ const productCapacityPerPools = {
       allocatedNxm: '0',
       availableCapacity: [
         {
-          amount: '3746408544388139489',
+          amount: '3746457888581601216',
           asset: {
             decimals: 18,
             id: 0,
@@ -245,7 +245,7 @@ const productCapacityPerPools = {
           assetId: 0,
         },
         {
-          amount: '10468196676889266640830',
+          amount: '10468334554196532976463',
           asset: {
             decimals: 18,
             id: 1,
@@ -254,7 +254,7 @@ const productCapacityPerPools = {
           assetId: 1,
         },
         {
-          amount: '10468196671',
+          amount: '10468334549',
           asset: {
             decimals: 6,
             id: 6,
@@ -263,7 +263,7 @@ const productCapacityPerPools = {
           assetId: 6,
         },
         {
-          amount: '29983541',
+          amount: '29983936',
           asset: {
             decimals: 8,
             id: 7,
@@ -272,7 +272,7 @@ const productCapacityPerPools = {
           assetId: 7,
         },
         {
-          amount: '364435200000000000000',
+          amount: '364440000000000000000',
           asset: {
             decimals: 18,
             id: 255,
@@ -307,27 +307,27 @@ const poolProductCapacities = {
         availableCapacity: [
           {
             assetId: 0,
-            amount: '3746408544388139489',
+            amount: '3746457888581601216',
             asset: { id: 0, symbol: 'ETH', decimals: 18 },
           },
           {
             assetId: 1,
-            amount: '10468196676889266640830',
+            amount: '10468334554196532976463',
             asset: { id: 1, symbol: 'DAI', decimals: 18 },
           },
           {
             assetId: 6,
-            amount: '10468196671',
+            amount: '10468334549',
             asset: { id: 6, symbol: 'USDC', decimals: 6 },
           },
           {
             assetId: 7,
-            amount: '29983541',
+            amount: '29983936',
             asset: { id: 7, symbol: 'cbBTC', decimals: 8 },
           },
           {
             assetId: 255,
-            amount: '364435200000000000000',
+            amount: '364440000000000000000',
             asset: { id: 255, symbol: 'NXM', decimals: 18 },
           },
         ],
@@ -340,27 +340,27 @@ const poolProductCapacities = {
         availableCapacity: [
           {
             assetId: 0,
-            amount: '3746408544388139489',
+            amount: '3746457888581601216',
             asset: { id: 0, symbol: 'ETH', decimals: 18 },
           },
           {
             assetId: 1,
-            amount: '10468196676889266640830',
+            amount: '10468334554196532976463',
             asset: { id: 1, symbol: 'DAI', decimals: 18 },
           },
           {
             assetId: 6,
-            amount: '10468196671',
+            amount: '10468334549',
             asset: { id: 6, symbol: 'USDC', decimals: 6 },
           },
           {
             assetId: 7,
-            amount: '29983541',
+            amount: '29983936',
             asset: { id: 7, symbol: 'cbBTC', decimals: 8 },
           },
           {
             assetId: 255,
-            amount: '364435200000000000000',
+            amount: '364440000000000000000',
             asset: { id: 255, symbol: 'NXM', decimals: 18 },
           },
         ],
@@ -373,27 +373,27 @@ const poolProductCapacities = {
         availableCapacity: [
           {
             assetId: 0,
-            amount: '3746408544388139489',
+            amount: '3746457888581601216',
             asset: { id: 0, symbol: 'ETH', decimals: 18 },
           },
           {
             assetId: 1,
-            amount: '10468196676889266640830',
+            amount: '10468334554196532976463',
             asset: { id: 1, symbol: 'DAI', decimals: 18 },
           },
           {
             assetId: 6,
-            amount: '10468196671',
+            amount: '10468334549',
             asset: { id: 6, symbol: 'USDC', decimals: 6 },
           },
           {
             assetId: 7,
-            amount: '29983541',
+            amount: '29983936',
             asset: { id: 7, symbol: 'cbBTC', decimals: 8 },
           },
           {
             assetId: 255,
-            amount: '364435200000000000000',
+            amount: '364440000000000000000',
             asset: { id: 255, symbol: 'NXM', decimals: 18 },
           },
         ],


### PR DESCRIPTION
## Description

Available capacity should be rounded down in nxm allocation units

## Testing

Explain how you tested your changes to ensure they work as expected.

## Checklist

- [ ] Performed a self-review of my own code
- [ ] Made corresponding changes to the documentation
