### PR TITLE
fix: remove capacities response from the quote route

### DIFF
--- a/src/lib/quoteEngine.js
+++ b/src/lib/quoteEngine.js
@@ -7,7 +7,6 @@ const {
   calculateBasePrice,
   calculatePremiumPerYear,
   calculateAvailableCapacityInNXM,
-  getCapacitiesInAssets,
   getCoverTrancheAllocations,
   calculateCoverRefundInNXM,
   divCeil,
@@ -113,7 +112,6 @@ const quoteEngine = (store, productId, amount, period, coverAsset, editedCoverId
 
   const productPools = selectProductPools(store, productId);
   const assetRate = selectAssetRate(store, coverAsset);
-  const { assets, assetRates } = store.getState();
 
   const now = BigNumber.from(Date.now()).div(1000);
   const firstUsableTrancheIndex = calculateFirstUsableTrancheIndex(now, product.gracePeriod, period);
@@ -172,26 +170,6 @@ const quoteEngine = (store, productId, amount, period, coverAsset, editedCoverId
     };
   });
 
-  const { availableCapacityInNXM, perPool: capacitiesPerPool } = poolsWithPremium.reduce(
-    (totals, pool) => {
-      return {
-        availableCapacityInNXM: totals.availableCapacityInNXM.add(pool.availableCapacityInNXM),
-        perPool: [
-          ...totals.perPool,
-          {
-            poolId: pool.poolId,
-            capacity: getCapacitiesInAssets(pool.availableCapacityInNXM, assets, assetRates),
-          },
-        ],
-      };
-    },
-    {
-      availableCapacityInNXM: Zero,
-      perPool: [],
-    },
-  );
-  const availableCapacity = getCapacitiesInAssets(availableCapacityInNXM, assets, assetRates);
-
   const { premiumInNXM, premiumInAsset, coverAmountInAsset } = poolsWithPremium.reduce(
     (totals, pool) => {
       return {
@@ -218,8 +196,6 @@ const quoteEngine = (store, productId, amount, period, coverAsset, editedCoverId
 
   return {
     poolsWithPremium,
-    availableCapacity,
-    capacitiesPerPool,
     premiumInNXM,
     premiumInAsset,
     refundInNXM,

--- a/src/routes/capacity.js
+++ b/src/routes/capacity.js
@@ -86,7 +86,6 @@ router.get(
   }),
 );
 
-// TODO: update openapi
 /**
  * @openapi
  * /v2/capacity/{productId}:
@@ -109,6 +108,12 @@ router.get(
  *           maximum: 365
  *           default: 30
  *         description: Coverage period in days
+ *       - in: query
+ *         name: coverEditId
+ *         required: false
+ *         schema:
+ *           type: integer
+ *           description: The id of the cover that is being edited
  *     responses:
  *       200:
  *         description: Returns capacity data for a product, including capacityPerPool data.

--- a/src/routes/quote.js
+++ b/src/routes/quote.js
@@ -7,7 +7,6 @@ const { selectAsset } = require('../store/selectors');
 
 const router = express.Router();
 
-// TODO: change openapi desc
 /**
  * @openapi
  * /v2/quote:
@@ -41,7 +40,7 @@ const router = express.Router();
  *         type: integer
  *         description: The cover asset assetId (e.g. 0 for ETH, 1 for DAI)
  *     - in: query
- *       name: editedCoverId
+ *       name: coverEditId
  *       required: false
  *       schema:
  *         type: integer
@@ -108,42 +107,6 @@ const router = express.Router();
  *                           type: integer
  *                           description: The decimals of the cover asset
  *                           example: 18
- *                 capacities:
- *                   type: array
- *                   description: Show the pools with sufficient (and cheapest) capacity for the requested cover.
- *                   items:
- *                     type: object
- *                     properties:
- *                       poolId:
- *                         type: string
- *                         description: The pool id
- *                       capacity:
- *                         type: array
- *                         items:
- *                           type: object
- *                           properties:
- *                             assetId:
- *                               type: string
- *                               format: integer
- *                               description: The id of the asset
- *                             amount:
- *                               type: string
- *                               format: integer
- *                               description: The total capacity amount of the pool expressed in the asset.
- *                             asset:
- *                               type: object
- *                               description: An object containing asset info
- *                               properties:
- *                                 id:
- *                                   type: integer
- *                                   description: The id of the asset
- *                                 symbol:
- *                                   type: string
- *                                   description: The symbol of the asset
- *                                 decimals:
- *                                   type: integer
- *                                   description: The decimals of the asset
- *                                   example: 18
  *       400:
  *         description: Invalid Product Id, or Product is deprecated, or Not enough capacity, or Not original cover id
  */
@@ -183,19 +146,6 @@ router.get(
           poolAllocationRequests,
           asset: selectAsset(store, coverAsset),
         },
-        availableCapacity: route.availableCapacity.map(({ assetId, amount, asset }) => ({
-          assetId: assetId.toString(),
-          amount: amount.toString(),
-          asset,
-        })),
-        capacitiesPerPool: route.capacitiesPerPool.map(({ poolId, capacity }) => ({
-          poolId: poolId.toString(),
-          capacity: capacity.map(({ assetId, amount, asset }) => ({
-            assetId: assetId.toString(),
-            amount: amount.toString(),
-            asset,
-          })),
-        })),
       },
     };
   }),

--- a/test/unit/responses.js
+++ b/test/unit/responses.js
@@ -467,65 +467,6 @@ const getQuote = assetId => ({
     ...quoteMapping[assetId],
     asset: assets[assetId],
   },
-  availableCapacity: [
-    {
-      assetId: '0',
-      amount: '1010527961934945120',
-      asset: assets[0],
-    },
-    {
-      assetId: '1',
-      amount: '2823612355058498495188',
-      asset: assets[1],
-    },
-    {
-      assetId: '6',
-      amount: '2823612353',
-      asset: assets[6],
-    },
-    {
-      assetId: '7',
-      amount: '8087534',
-      asset: assets[7],
-    },
-    {
-      assetId: '255',
-      amount: '98300000000000000000',
-      asset: assets[255],
-    },
-  ],
-  capacitiesPerPool: [
-    {
-      poolId: '1',
-      capacity: [
-        {
-          assetId: '0',
-          amount: '1010527961934945120',
-          asset: assets[0],
-        },
-        {
-          assetId: '1',
-          amount: '2823612355058498495188',
-          asset: assets[1],
-        },
-        {
-          assetId: '6',
-          amount: '2823612353',
-          asset: assets[6],
-        },
-        {
-          assetId: '7',
-          amount: '8087534',
-          asset: assets[7],
-        },
-        {
-          assetId: '255',
-          amount: '98300000000000000000',
-          asset: assets[255],
-        },
-      ],
-    },
-  ],
 });
 
 module.exports = {


### PR DESCRIPTION
## Description

Removed `availableCapacity` and `capacitiesPerPool` from the quote route since we now can get it from the capacity route with edited cover accounted as well.

## Testing

Explain how you tested your changes to ensure they work as expected.

## Checklist

- [ ] Performed a self-review of my own code
- [ ] Made corresponding changes to the documentation
